### PR TITLE
feat: 동물 조회/검색 페이지 구현

### DIFF
--- a/src/api/animals.api.mock.ts
+++ b/src/api/animals.api.mock.ts
@@ -1,6 +1,14 @@
 import type { Animal } from '../types/api.types';
 
-// Mock 데이터 (개발용)
+// 오늘 날짜 기준 계산
+const today = new Date();
+const getDateAfterDays = (days: number): string => {
+  const date = new Date(today);
+  date.setDate(date.getDate() + days);
+  return date.toISOString().split('T')[0];
+};
+
+// Mock 데이터 (APMS 공공데이터 형식)
 export const mockAnimals: Animal[] = [
   {
     id: 1,
@@ -11,6 +19,17 @@ export const mockAnimals: Animal[] = [
     gender: 'MALE',
     imageUrl: '',
     status: 'AVAILABLE',
+    noticeNo: 'SEOUL-2024-001234',
+    noticeStartDate: getDateAfterDays(-10),
+    noticeEndDate: getDateAfterDays(2), // D-2
+    region: '서울',
+    city: '강남구',
+    foundPlace: '강남역 인근',
+    shelterName: '서울시 동물보호센터',
+    weight: '10kg',
+    color: '갈색, 흰색',
+    neutered: true,
+    description: '사람을 매우 좋아하고 활발한 성격입니다. 산책을 좋아해요.',
   },
   {
     id: 2,
@@ -21,6 +40,17 @@ export const mockAnimals: Animal[] = [
     gender: 'FEMALE',
     imageUrl: '',
     status: 'AVAILABLE',
+    noticeNo: 'BUSAN-2024-005678',
+    noticeStartDate: getDateAfterDays(-5),
+    noticeEndDate: getDateAfterDays(5), // D-5
+    region: '부산',
+    city: '해운대구',
+    foundPlace: '해운대 해수욕장 근처',
+    shelterName: '부산 동물사랑센터',
+    weight: '3.5kg',
+    color: '검은색',
+    neutered: false,
+    description: '조용하고 얌전한 성격이에요. 스킨십을 좋아합니다.',
   },
   {
     id: 3,
@@ -31,6 +61,17 @@ export const mockAnimals: Animal[] = [
     gender: 'FEMALE',
     imageUrl: '',
     status: 'AVAILABLE',
+    noticeNo: 'INCHEON-2024-003456',
+    noticeStartDate: getDateAfterDays(-15),
+    noticeEndDate: getDateAfterDays(0), // D-DAY
+    region: '인천',
+    city: '남동구',
+    foundPlace: '소래포구 인근',
+    shelterName: '인천 유기동물보호소',
+    weight: '5kg',
+    color: '갈색',
+    neutered: true,
+    description: '작고 귀여워요. 다른 강아지들과도 잘 지냅니다.',
   },
   {
     id: 4,
@@ -41,6 +82,17 @@ export const mockAnimals: Animal[] = [
     gender: 'MALE',
     imageUrl: '',
     status: 'AVAILABLE',
+    noticeNo: 'SEOUL-2024-007890',
+    noticeStartDate: getDateAfterDays(-3),
+    noticeEndDate: getDateAfterDays(7), // D-7
+    region: '서울',
+    city: '송파구',
+    foundPlace: '잠실 롯데월드 근처',
+    shelterName: '서울시 동물보호센터',
+    weight: '4kg',
+    color: '흰색, 갈색',
+    neutered: false,
+    description: '아직 어려서 매우 활발해요. 사회화 교육이 필요합니다.',
   },
   {
     id: 5,
@@ -51,6 +103,17 @@ export const mockAnimals: Animal[] = [
     gender: 'FEMALE',
     imageUrl: '',
     status: 'ADOPTED',
+    noticeNo: 'GYEONGGI-2024-002345',
+    noticeStartDate: getDateAfterDays(-20),
+    noticeEndDate: getDateAfterDays(-10),
+    region: '경기',
+    city: '성남시',
+    foundPlace: '판교테크노밸리',
+    shelterName: '경기도 동물보호센터',
+    weight: '4kg',
+    color: '회색',
+    neutered: true,
+    description: '조용하고 독립적인 성격입니다. 입양 완료되었어요!',
   },
   {
     id: 6,
@@ -61,6 +124,17 @@ export const mockAnimals: Animal[] = [
     gender: 'MALE',
     imageUrl: '',
     status: 'AVAILABLE',
+    noticeNo: 'DAEGU-2024-004567',
+    noticeStartDate: getDateAfterDays(-8),
+    noticeEndDate: getDateAfterDays(4), // D-4
+    region: '대구',
+    city: '수성구',
+    foundPlace: '수성못 공원',
+    shelterName: '대구 동물보호센터',
+    weight: '5kg',
+    color: '흰색',
+    neutered: true,
+    description: '고급스러운 장모종이에요. 털 관리가 필요합니다.',
   },
   {
     id: 7,
@@ -71,6 +145,17 @@ export const mockAnimals: Animal[] = [
     gender: 'MALE',
     imageUrl: '',
     status: 'AVAILABLE',
+    noticeNo: 'GWANGJU-2024-006789',
+    noticeStartDate: getDateAfterDays(-12),
+    noticeEndDate: getDateAfterDays(1), // D-1
+    region: '광주',
+    city: '서구',
+    foundPlace: '광주천 산책로',
+    shelterName: '광주 동물보호센터',
+    weight: '12kg',
+    color: '갈색, 흰색',
+    neutered: false,
+    description: '활발하고 에너지가 넘쳐요. 넓은 공간이 필요합니다.',
   },
   {
     id: 8,
@@ -81,6 +166,17 @@ export const mockAnimals: Animal[] = [
     gender: 'FEMALE',
     imageUrl: '',
     status: 'AVAILABLE',
+    noticeNo: 'DAEJEON-2024-008901',
+    noticeStartDate: getDateAfterDays(-2),
+    noticeEndDate: getDateAfterDays(10), // D-10
+    region: '대전',
+    city: '유성구',
+    foundPlace: '카이스트 캠퍼스 근처',
+    shelterName: '대전 유기동물보호센터',
+    weight: '3kg',
+    color: '갈색 얼룩무늬',
+    neutered: false,
+    description: '야생적인 무늬가 아름다워요. 활동적이고 호기심이 많습니다.',
   },
   {
     id: 9,
@@ -91,6 +187,17 @@ export const mockAnimals: Animal[] = [
     gender: 'MALE',
     imageUrl: '',
     status: 'AVAILABLE',
+    noticeNo: 'ULSAN-2024-009012',
+    noticeStartDate: getDateAfterDays(-18),
+    noticeEndDate: getDateAfterDays(-2), // 공고 종료 2일 지남
+    region: '울산',
+    city: '남구',
+    foundPlace: '태화강 국가정원',
+    shelterName: '울산 동물보호센터',
+    weight: '18kg',
+    color: '흰색',
+    neutered: true,
+    description: '충성스럽고 영리해요. 주인에게 한없이 헌신적입니다.',
   },
   {
     id: 10,
@@ -101,6 +208,17 @@ export const mockAnimals: Animal[] = [
     gender: 'FEMALE',
     imageUrl: '',
     status: 'ADOPTED',
+    noticeNo: 'SEJONG-2024-001122',
+    noticeStartDate: getDateAfterDays(-25),
+    noticeEndDate: getDateAfterDays(-15),
+    region: '세종',
+    city: '세종시',
+    foundPlace: '세종호수공원',
+    shelterName: '세종시 동물보호센터',
+    weight: '3.5kg',
+    color: '크림색',
+    neutered: true,
+    description: '접힌 귀가 매력적이에요. 입양 완료되었습니다!',
   },
   {
     id: 11,
@@ -111,6 +229,17 @@ export const mockAnimals: Animal[] = [
     gender: 'FEMALE',
     imageUrl: '',
     status: 'AVAILABLE',
+    noticeNo: 'GYEONGGI-2024-003344',
+    noticeStartDate: getDateAfterDays(-7),
+    noticeEndDate: getDateAfterDays(3), // D-3
+    region: '경기',
+    city: '수원시',
+    foundPlace: '수원 화성 행궁',
+    shelterName: '경기도 동물보호센터',
+    weight: '3kg',
+    color: '오렌지색',
+    neutered: true,
+    description: '작고 귀여워요. 사람을 매우 좋아하고 애교가 많습니다.',
   },
   {
     id: 12,
@@ -121,6 +250,80 @@ export const mockAnimals: Animal[] = [
     gender: 'MALE',
     imageUrl: '',
     status: 'AVAILABLE',
+    noticeNo: 'BUSAN-2024-005566',
+    noticeStartDate: getDateAfterDays(-14),
+    noticeEndDate: getDateAfterDays(6), // D-6
+    region: '부산',
+    city: '중구',
+    foundPlace: '부산역 광장',
+    shelterName: '부산 동물사랑센터',
+    weight: '4.5kg',
+    color: '검은색',
+    neutered: true,
+    description: '검은 표범 같은 외모예요. 차분하고 온순한 성격입니다.',
+  },
+  {
+    id: 13,
+    name: '루비',
+    species: '강아지',
+    breed: '비글',
+    age: 3,
+    gender: 'FEMALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+    noticeNo: 'SEOUL-2024-009988',
+    noticeStartDate: getDateAfterDays(-6),
+    noticeEndDate: getDateAfterDays(8), // D-8
+    region: '서울',
+    city: '마포구',
+    foundPlace: '상암 월드컵공원',
+    shelterName: '서울시 동물보호센터',
+    weight: '11kg',
+    color: '갈색, 흰색, 검은색',
+    neutered: false,
+    description: '호기심이 많고 후각이 발달했어요. 산책을 매우 좋아합니다.',
+  },
+  {
+    id: 14,
+    name: '토리',
+    species: '고양이',
+    breed: '터키시 앙고라',
+    age: 2,
+    gender: 'MALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+    noticeNo: 'INCHEON-2024-007744',
+    noticeStartDate: getDateAfterDays(-4),
+    noticeEndDate: getDateAfterDays(9), // D-9
+    region: '인천',
+    city: '연수구',
+    foundPlace: '송도 센트럴파크',
+    shelterName: '인천 유기동물보호소',
+    weight: '3.8kg',
+    color: '흰색',
+    neutered: true,
+    description: '우아하고 긴 털을 가진 고양이예요. 조용한 환경을 좋아합니다.',
+  },
+  {
+    id: 15,
+    name: '땅콩이',
+    species: '강아지',
+    breed: '닥스훈트',
+    age: 5,
+    gender: 'MALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+    noticeNo: 'GYEONGGI-2024-006655',
+    noticeStartDate: getDateAfterDays(-11),
+    noticeEndDate: getDateAfterDays(1), // D-1
+    region: '경기',
+    city: '고양시',
+    foundPlace: '일산 호수공원',
+    shelterName: '경기도 동물보호센터',
+    weight: '7kg',
+    color: '갈색',
+    neutered: true,
+    description: '짧은 다리가 귀여워요. 용감하고 충성스러운 성격입니다.',
   },
 ];
 
@@ -131,3 +334,13 @@ export const getMockAnimals = async (): Promise<Animal[]> => {
   return mockAnimals;
 };
 
+// D-day 계산 헬퍼 함수
+export const calculateDday = (endDate: string): number => {
+  const end = new Date(endDate);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  end.setHours(0, 0, 0, 0);
+  const diffTime = end.getTime() - today.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  return diffDays;
+};

--- a/src/api/animals.api.mock.ts
+++ b/src/api/animals.api.mock.ts
@@ -1,0 +1,133 @@
+import type { Animal } from '../types/api.types';
+
+// Mock 데이터 (개발용)
+export const mockAnimals: Animal[] = [
+  {
+    id: 1,
+    name: '뭉치',
+    species: '강아지',
+    breed: '믹스견',
+    age: 3,
+    gender: 'MALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+  },
+  {
+    id: 2,
+    name: '나비',
+    species: '고양이',
+    breed: '코리안 숏헤어',
+    age: 2,
+    gender: 'FEMALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+  },
+  {
+    id: 3,
+    name: '초코',
+    species: '강아지',
+    breed: '푸들',
+    age: 5,
+    gender: 'FEMALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+  },
+  {
+    id: 4,
+    name: '호두',
+    species: '강아지',
+    breed: '시츄',
+    age: 1,
+    gender: 'MALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+  },
+  {
+    id: 5,
+    name: '별이',
+    species: '고양이',
+    breed: '러시안 블루',
+    age: 4,
+    gender: 'FEMALE',
+    imageUrl: '',
+    status: 'ADOPTED',
+  },
+  {
+    id: 6,
+    name: '구름',
+    species: '고양이',
+    breed: '페르시안',
+    age: 3,
+    gender: 'MALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+  },
+  {
+    id: 7,
+    name: '콩이',
+    species: '강아지',
+    breed: '웰시코기',
+    age: 2,
+    gender: 'MALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+  },
+  {
+    id: 8,
+    name: '달이',
+    species: '고양이',
+    breed: '벵갈',
+    age: 1,
+    gender: 'FEMALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+  },
+  {
+    id: 9,
+    name: '바둑이',
+    species: '강아지',
+    breed: '진돗개',
+    age: 6,
+    gender: 'MALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+  },
+  {
+    id: 10,
+    name: '치즈',
+    species: '고양이',
+    breed: '스코티시 폴드',
+    age: 2,
+    gender: 'FEMALE',
+    imageUrl: '',
+    status: 'ADOPTED',
+  },
+  {
+    id: 11,
+    name: '복실이',
+    species: '강아지',
+    breed: '포메라니안',
+    age: 4,
+    gender: 'FEMALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+  },
+  {
+    id: 12,
+    name: '까망이',
+    species: '고양이',
+    breed: '봄베이',
+    age: 3,
+    gender: 'MALE',
+    imageUrl: '',
+    status: 'AVAILABLE',
+  },
+];
+
+// Mock API 함수
+export const getMockAnimals = async (): Promise<Animal[]> => {
+  // 네트워크 지연 시뮬레이션
+  await new Promise(resolve => setTimeout(resolve, 500));
+  return mockAnimals;
+};
+

--- a/src/components/common/AnimalCard.tsx
+++ b/src/components/common/AnimalCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { Animal } from '../../types/api.types';
+import { calculateDday } from '../../api/animals.api.mock';
 
 interface AnimalCardProps {
   animal: Animal;
@@ -12,63 +13,98 @@ export default function AnimalCard({ animal, onFavorite }: AnimalCardProps) {
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
     e.preventDefault();
+    e.stopPropagation();
     setIsFavorited(!isFavorited);
     if (onFavorite) {
       onFavorite(animal.id);
     }
   };
 
+  // D-day 계산
+  const dday = animal.noticeEndDate ? calculateDday(animal.noticeEndDate) : null;
+  const isDdayUrgent = dday !== null && dday <= 3 && dday >= 0;
+  const isDdayExpired = dday !== null && dday < 0;
+
   return (
-    <div className="group bg-white rounded-2xl shadow-md hover:shadow-2xl transition-all duration-300 overflow-hidden">
+    <div className="group bg-white rounded-2xl shadow-md hover:shadow-2xl transition-all duration-300 overflow-hidden cursor-pointer transform hover:-translate-y-1">
       {/* 이미지 영역 */}
-      <div className="relative w-full h-56 bg-gradient-to-br from-blue-50 to-blue-100 overflow-hidden">
+      <div className="relative w-full h-64 bg-gradient-to-br from-blue-50 to-blue-100 overflow-hidden">
         {!imageError && animal.imageUrl ? (
           <img
             src={animal.imageUrl}
             alt={animal.name}
-            className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
+            className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500"
             onError={() => setImageError(true)}
           />
         ) : (
           <div className="w-full h-full flex items-center justify-center">
-            <span className="text-7xl">
+            <span className="text-8xl animate-bounce">
               {animal.species === '강아지' ? '🐕' : '🐈'}
             </span>
           </div>
         )}
 
+        {/* 그라데이션 오버레이 */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+
         {/* 찜하기 버튼 */}
         <button
           onClick={handleFavoriteClick}
-          className="absolute top-3 right-3 w-10 h-10 bg-white rounded-full shadow-lg flex items-center justify-center hover:scale-110 transition-transform"
+          className="absolute top-3 right-3 w-11 h-11 bg-white/90 backdrop-blur-sm rounded-full shadow-lg flex items-center justify-center hover:scale-110 active:scale-95 transition-transform z-10"
         >
           <svg
-            className={`w-6 h-6 ${isFavorited ? 'fill-red-500' : 'fill-gray-300'}`}
+            className={`w-6 h-6 transition-all duration-300 ${
+              isFavorited ? 'fill-red-500 scale-110' : 'fill-gray-300'
+            }`}
             viewBox="0 0 24 24"
           >
             <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
           </svg>
         </button>
 
+        {/* D-day 배지 */}
+        {dday !== null && !isDdayExpired && (
+          <div className="absolute top-3 left-3">
+            <div
+              className={`px-3 py-1.5 rounded-full font-bold text-sm shadow-lg backdrop-blur-sm ${
+                isDdayUrgent
+                  ? 'bg-red-500 text-white animate-pulse'
+                  : 'bg-white/90 text-gray-800'
+              }`}
+            >
+              {dday === 0 ? '⏰ D-DAY' : `⏰ D-${dday}`}
+            </div>
+          </div>
+        )}
+
         {/* 입양 상태 배지 */}
         <div className="absolute bottom-3 left-3">
           <span
-            className={`inline-block px-3 py-1 rounded-full text-sm font-bold shadow-md ${
+            className={`inline-block px-3 py-1.5 rounded-full text-sm font-bold shadow-md backdrop-blur-sm ${
               animal.status === 'AVAILABLE'
-                ? 'bg-green-500 text-white'
-                : 'bg-gray-400 text-white'
+                ? 'bg-green-500/90 text-white'
+                : 'bg-gray-600/90 text-white'
             }`}
           >
-            {animal.status === 'AVAILABLE' ? '입양 가능' : '입양 완료'}
+            {animal.status === 'AVAILABLE' ? '✅ 입양 가능' : '💝 입양 완료'}
           </span>
         </div>
       </div>
 
       {/* 정보 영역 */}
       <div className="p-5">
-        <h3 className="text-xl font-bold text-gray-800 mb-3">{animal.name}</h3>
+        {/* 이름과 공고번호 */}
+        <div className="mb-3">
+          <h3 className="text-2xl font-bold text-gray-800 mb-1 group-hover:text-blue-600 transition-colors">
+            {animal.name}
+          </h3>
+          {animal.noticeNo && (
+            <p className="text-xs text-gray-500 font-mono">{animal.noticeNo}</p>
+          )}
+        </div>
 
-        <div className="space-y-2">
+        {/* 주요 정보 */}
+        <div className="space-y-2 mb-4">
           <InfoRow icon="🐾" label="품종" value={animal.breed} />
           <InfoRow icon="🎂" label="나이" value={`${animal.age}살`} />
           <InfoRow
@@ -76,11 +112,108 @@ export default function AnimalCard({ animal, onFavorite }: AnimalCardProps) {
             label="성별"
             value={animal.gender === 'MALE' ? '수컷' : '암컷'}
           />
+          {animal.weight && <InfoRow icon="⚖️" label="체중" value={animal.weight} />}
+        </div>
+
+        {/* 위치 정보 */}
+        {(animal.region || animal.city || animal.foundPlace) && (
+          <div className="mb-4 p-3 bg-blue-50 rounded-lg">
+            <div className="flex items-start gap-2">
+              <svg
+                className="w-5 h-5 text-blue-500 flex-shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-semibold text-gray-800">
+                  {animal.region && animal.city
+                    ? `${animal.region} ${animal.city}`
+                    : animal.region || animal.city || '위치 정보 없음'}
+                </p>
+                {animal.foundPlace && (
+                  <p className="text-xs text-gray-600 mt-1 line-clamp-1">
+                    발견: {animal.foundPlace}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 설명 */}
+        {animal.description && (
+          <p className="text-sm text-gray-600 mb-4 line-clamp-2 leading-relaxed">
+            {animal.description}
+          </p>
+        )}
+
+        {/* 보호소 정보 */}
+        {animal.shelterName && (
+          <div className="flex items-center gap-2 mb-4 text-xs text-gray-500">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+              />
+            </svg>
+            <span className="truncate">{animal.shelterName}</span>
+          </div>
+        )}
+
+        {/* 특징 태그 */}
+        <div className="flex flex-wrap gap-2 mb-4">
+          {animal.color && (
+            <span className="px-2 py-1 bg-gray-100 text-gray-700 text-xs rounded-md">
+              {animal.color}
+            </span>
+          )}
+          {animal.neutered !== undefined && (
+            <span
+              className={`px-2 py-1 text-xs rounded-md ${
+                animal.neutered
+                  ? 'bg-blue-100 text-blue-700'
+                  : 'bg-amber-100 text-amber-700'
+              }`}
+            >
+              {animal.neutered ? '중성화 ✓' : '중성화 X'}
+            </span>
+          )}
         </div>
 
         {/* 상세보기 버튼 */}
-        <button className="mt-4 w-full py-3 bg-blue-500 text-white font-semibold rounded-xl hover:bg-blue-600 transition-colors">
-          상세보기
+        <button className="w-full py-3 bg-gradient-to-r from-blue-500 to-blue-600 text-white font-bold rounded-xl hover:from-blue-600 hover:to-blue-700 transition-all shadow-md hover:shadow-lg transform group-hover:scale-105">
+          <span className="flex items-center justify-center gap-2">
+            상세보기
+            <svg
+              className="w-5 h-5 group-hover:translate-x-1 transition-transform"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          </span>
         </button>
       </div>
     </div>
@@ -96,12 +229,11 @@ interface InfoRowProps {
 
 function InfoRow({ icon, label, value }: InfoRowProps) {
   return (
-    <div className="flex items-center text-gray-600">
-      <span className="mr-2">{icon}</span>
+    <div className="flex items-center text-gray-700">
+      <span className="mr-2 text-lg">{icon}</span>
       <span className="text-sm">
-        <span className="font-semibold">{label}:</span> {value}
+        <span className="font-semibold text-gray-800">{label}:</span> {value}
       </span>
     </div>
   );
 }
-

--- a/src/components/common/AnimalFilters.tsx
+++ b/src/components/common/AnimalFilters.tsx
@@ -1,105 +1,205 @@
+import { useState } from 'react';
+
 interface AnimalFiltersProps {
   filters: {
     species: string;
     gender: string;
     status: string;
+    region: string;
     sortBy: string;
   };
   onFilterChange: (key: string, value: string) => void;
 }
 
 export default function AnimalFilters({ filters, onFilterChange }: AnimalFiltersProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  // 활성화된 필터 개수 계산
+  const activeFilterCount = Object.values(filters).filter(
+    (value, index) => value !== '' && index !== 4 // sortBy 제외
+  ).length;
+
   return (
-    <div className="bg-white rounded-xl shadow-md p-6">
-      <h3 className="text-lg font-bold text-gray-800 mb-4">필터</h3>
-      
-      <div className="space-y-4">
-        {/* 종류 */}
-        <div>
-          <label className="block text-sm font-semibold text-gray-700 mb-2">
-            종류
-          </label>
-          <div className="flex flex-wrap gap-2">
-            <FilterButton
-              label="전체"
-              active={filters.species === ''}
-              onClick={() => onFilterChange('species', '')}
-            />
-            <FilterButton
-              label="🐕 강아지"
-              active={filters.species === '강아지'}
-              onClick={() => onFilterChange('species', '강아지')}
-            />
-            <FilterButton
-              label="🐈 고양이"
-              active={filters.species === '고양이'}
-              onClick={() => onFilterChange('species', '고양이')}
-            />
-          </div>
-        </div>
-
-        {/* 성별 */}
-        <div>
-          <label className="block text-sm font-semibold text-gray-700 mb-2">
-            성별
-          </label>
-          <div className="flex flex-wrap gap-2">
-            <FilterButton
-              label="전체"
-              active={filters.gender === ''}
-              onClick={() => onFilterChange('gender', '')}
-            />
-            <FilterButton
-              label="수컷"
-              active={filters.gender === 'MALE'}
-              onClick={() => onFilterChange('gender', 'MALE')}
-            />
-            <FilterButton
-              label="암컷"
-              active={filters.gender === 'FEMALE'}
-              onClick={() => onFilterChange('gender', 'FEMALE')}
-            />
-          </div>
-        </div>
-
-        {/* 입양 상태 */}
-        <div>
-          <label className="block text-sm font-semibold text-gray-700 mb-2">
-            입양 상태
-          </label>
-          <div className="flex flex-wrap gap-2">
-            <FilterButton
-              label="전체"
-              active={filters.status === ''}
-              onClick={() => onFilterChange('status', '')}
-            />
-            <FilterButton
-              label="입양 가능"
-              active={filters.status === 'AVAILABLE'}
-              onClick={() => onFilterChange('status', 'AVAILABLE')}
-            />
-            <FilterButton
-              label="입양 완료"
-              active={filters.status === 'ADOPTED'}
-              onClick={() => onFilterChange('status', 'ADOPTED')}
-            />
-          </div>
-        </div>
-
-        {/* 정렬 */}
-        <div>
-          <label className="block text-sm font-semibold text-gray-700 mb-2">
-            정렬
-          </label>
-          <select
-            value={filters.sortBy}
-            onChange={(e) => onFilterChange('sortBy', e.target.value)}
-            className="w-full px-4 py-2 border-2 border-gray-200 rounded-lg focus:outline-none focus:border-blue-500 transition-colors"
+    <div className="bg-white rounded-xl shadow-md overflow-hidden">
+      {/* 헤더 (모바일에서 토글 가능) */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full p-6 flex items-center justify-between hover:bg-gray-50 transition-colors lg:cursor-default"
+      >
+        <div className="flex items-center gap-3">
+          <svg
+            className="w-5 h-5 text-blue-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            <option value="latest">최신순</option>
-            <option value="name">이름순</option>
-            <option value="age">나이순</option>
-          </select>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"
+            />
+          </svg>
+          <h3 className="text-lg font-bold text-gray-800">필터</h3>
+          {activeFilterCount > 0 && (
+            <span className="px-2 py-1 bg-blue-500 text-white text-xs font-bold rounded-full">
+              {activeFilterCount}
+            </span>
+          )}
+        </div>
+        <svg
+          className={`w-5 h-5 text-gray-400 transition-transform lg:hidden ${
+            isOpen ? 'rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {/* 필터 내용 */}
+      <div
+        className={`transition-all duration-300 ${
+          isOpen ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0 lg:max-h-[2000px] lg:opacity-100'
+        }`}
+      >
+        <div className="px-6 pb-6 space-y-6">
+          {/* 정렬 (맨 위로 이동 - 가장 중요) */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              정렬
+            </label>
+            <select
+              value={filters.sortBy}
+              onChange={(e) => onFilterChange('sortBy', e.target.value)}
+              className="w-full px-4 py-2.5 border-2 border-gray-200 rounded-lg focus:outline-none focus:border-blue-500 transition-colors font-medium"
+            >
+              <option value="urgent">🔥 공고 종료 임박</option>
+              <option value="latest">⏰ 최신순</option>
+              <option value="name">📝 이름순</option>
+              <option value="age">🎂 나이순</option>
+            </select>
+          </div>
+
+          {/* 지역 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              지역
+            </label>
+            <select
+              value={filters.region}
+              onChange={(e) => onFilterChange('region', e.target.value)}
+              className="w-full px-4 py-2.5 border-2 border-gray-200 rounded-lg focus:outline-none focus:border-blue-500 transition-colors"
+            >
+              <option value="">전체 지역</option>
+              <option value="서울">서울</option>
+              <option value="부산">부산</option>
+              <option value="대구">대구</option>
+              <option value="인천">인천</option>
+              <option value="광주">광주</option>
+              <option value="대전">대전</option>
+              <option value="울산">울산</option>
+              <option value="세종">세종</option>
+              <option value="경기">경기</option>
+              <option value="강원">강원</option>
+              <option value="충북">충북</option>
+              <option value="충남">충남</option>
+              <option value="전북">전북</option>
+              <option value="전남">전남</option>
+              <option value="경북">경북</option>
+              <option value="경남">경남</option>
+              <option value="제주">제주</option>
+            </select>
+          </div>
+
+          {/* 종류 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              종류
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <FilterButton
+                label="전체"
+                active={filters.species === ''}
+                onClick={() => onFilterChange('species', '')}
+              />
+              <FilterButton
+                label="🐕 강아지"
+                active={filters.species === '강아지'}
+                onClick={() => onFilterChange('species', '강아지')}
+              />
+              <FilterButton
+                label="🐈 고양이"
+                active={filters.species === '고양이'}
+                onClick={() => onFilterChange('species', '고양이')}
+              />
+            </div>
+          </div>
+
+          {/* 성별 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              성별
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <FilterButton
+                label="전체"
+                active={filters.gender === ''}
+                onClick={() => onFilterChange('gender', '')}
+              />
+              <FilterButton
+                label="♂ 수컷"
+                active={filters.gender === 'MALE'}
+                onClick={() => onFilterChange('gender', 'MALE')}
+              />
+              <FilterButton
+                label="♀ 암컷"
+                active={filters.gender === 'FEMALE'}
+                onClick={() => onFilterChange('gender', 'FEMALE')}
+              />
+            </div>
+          </div>
+
+          {/* 입양 상태 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              입양 상태
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <FilterButton
+                label="전체"
+                active={filters.status === ''}
+                onClick={() => onFilterChange('status', '')}
+              />
+              <FilterButton
+                label="✅ 입양 가능"
+                active={filters.status === 'AVAILABLE'}
+                onClick={() => onFilterChange('status', 'AVAILABLE')}
+              />
+              <FilterButton
+                label="💝 입양 완료"
+                active={filters.status === 'ADOPTED'}
+                onClick={() => onFilterChange('status', 'ADOPTED')}
+              />
+            </div>
+          </div>
+
+          {/* 필터 초기화 버튼 */}
+          {activeFilterCount > 0 && (
+            <button
+              onClick={() => {
+                onFilterChange('species', '');
+                onFilterChange('gender', '');
+                onFilterChange('status', '');
+                onFilterChange('region', '');
+              }}
+              className="w-full py-2.5 px-4 bg-gray-100 text-gray-700 rounded-lg font-semibold hover:bg-gray-200 transition-colors"
+            >
+              필터 초기화
+            </button>
+          )}
         </div>
       </div>
     </div>
@@ -119,12 +219,11 @@ function FilterButton({ label, active, onClick }: FilterButtonProps) {
       onClick={onClick}
       className={`px-4 py-2 rounded-lg font-medium transition-all ${
         active
-          ? 'bg-blue-500 text-white shadow-md'
-          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+          ? 'bg-blue-500 text-white shadow-md scale-105'
+          : 'bg-gray-100 text-gray-700 hover:bg-gray-200 hover:scale-105'
       }`}
     >
       {label}
     </button>
   );
 }
-

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,45 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* 커스텀 애니메이션 */
+@layer utilities {
+  .animate-fade-in {
+    animation: fadeIn 0.6s ease-in-out;
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+}
+
+/* 스크롤바 스타일링 */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #3b82f6;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #2563eb;
+}
+
+/* 부드러운 스크롤 */
+html {
+  scroll-behavior: smooth;
+}

--- a/src/pages/Animals.tsx
+++ b/src/pages/Animals.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getAnimals } from '../api/animals.api';
-import { getMockAnimals } from '../api/animals.api.mock';
+import { getMockAnimals, calculateDday } from '../api/animals.api.mock';
 import SearchBar from '../components/common/SearchBar';
 import AnimalFilters from '../components/common/AnimalFilters';
 import AnimalCard from '../components/common/AnimalCard';
@@ -13,12 +13,13 @@ export default function Animals() {
   // 검색어 상태
   const [searchQuery, setSearchQuery] = useState('');
   
-  // 필터 상태
+  // 필터 상태 (기본 정렬: 공고 종료 임박)
   const [filters, setFilters] = useState({
     species: '',
     gender: '',
     status: '',
-    sortBy: 'latest',
+    region: '',
+    sortBy: 'urgent',
   });
 
   // 데이터 가져오기 (Mock 또는 실제 API)
@@ -71,8 +72,21 @@ export default function Animals() {
       result = result.filter((animal) => animal.status === filters.status);
     }
 
+    // 지역 필터
+    if (filters.region) {
+      result = result.filter((animal) => animal.region === filters.region);
+    }
+
     // 정렬
     switch (filters.sortBy) {
+      case 'urgent':
+        // 공고 종료 임박순 (D-day가 작을수록 먼저)
+        result.sort((a, b) => {
+          const ddayA = a.noticeEndDate ? calculateDday(a.noticeEndDate) : 999;
+          const ddayB = b.noticeEndDate ? calculateDday(b.noticeEndDate) : 999;
+          return ddayA - ddayB;
+        });
+        break;
       case 'latest':
         // 최신순 (ID 역순)
         result.sort((a, b) => b.id - a.id);
@@ -93,14 +107,20 @@ export default function Animals() {
   // 로딩 상태
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white">
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-blue-50">
         <div className="max-w-7xl mx-auto px-4 py-12">
           <div className="flex flex-col items-center justify-center min-h-[400px]">
             <div className="relative">
-              <div className="w-16 h-16 border-4 border-blue-200 border-t-blue-500 rounded-full animate-spin"></div>
+              <div className="w-20 h-20 border-4 border-blue-200 border-t-blue-500 rounded-full animate-spin"></div>
+              <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-3xl">
+                🐾
+              </div>
             </div>
-            <p className="mt-6 text-lg text-gray-600 font-medium">
+            <p className="mt-8 text-xl text-gray-600 font-semibold animate-pulse">
               동물 친구들을 불러오고 있어요...
+            </p>
+            <p className="mt-2 text-sm text-gray-500">
+              잠시만 기다려주세요 💙
             </p>
           </div>
         </div>
@@ -111,13 +131,13 @@ export default function Animals() {
   // 에러 상태
   if (error) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white">
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-blue-50">
         <div className="max-w-7xl mx-auto px-4 py-12">
           <div className="flex items-center justify-center min-h-[400px]">
-            <div className="bg-white rounded-2xl shadow-xl p-8 max-w-md text-center">
-              <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <div className="bg-white rounded-2xl shadow-xl p-8 max-w-md text-center transform hover:scale-105 transition-transform">
+              <div className="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-6 animate-bounce">
                 <svg
-                  className="w-8 h-8 text-red-500"
+                  className="w-10 h-10 text-red-500"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -130,15 +150,17 @@ export default function Animals() {
                   />
                 </svg>
               </div>
-              <h2 className="text-2xl font-bold text-gray-800 mb-2">
+              <h2 className="text-2xl font-bold text-gray-800 mb-3">
                 에러가 발생했습니다
               </h2>
-              <p className="text-gray-600 mb-4">
+              <p className="text-gray-600 mb-6">
                 {error instanceof Error ? error.message : '알 수 없는 에러'}
               </p>
-              <p className="text-sm text-gray-500">
-                💡 백엔드 서버가 실행 중인지 확인해주세요
-              </p>
+              <div className="bg-blue-50 rounded-lg p-4">
+                <p className="text-sm text-gray-700">
+                  💡 <strong>해결 방법:</strong> 백엔드 서버가 실행 중인지 확인해주세요
+                </p>
+              </div>
             </div>
           </div>
         </div>
@@ -148,11 +170,11 @@ export default function Animals() {
 
   // 메인 UI
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-blue-50">
       <div className="max-w-7xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
         {/* 헤더 */}
-        <div className="mb-8">
-          <h1 className="text-4xl md:text-5xl font-bold text-gray-800 mb-3">
+        <div className="mb-8 text-center lg:text-left">
+          <h1 className="text-4xl md:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-blue-800 mb-3 animate-fade-in">
             🐾 새 가족을 찾아요
           </h1>
           <p className="text-lg text-gray-600">
@@ -164,42 +186,62 @@ export default function Animals() {
         <div className="mb-6">
           <SearchBar
             onSearch={handleSearch}
-            placeholder="동물 이름으로 검색..."
+            placeholder="동물 이름으로 검색해보세요..."
           />
         </div>
 
         {/* 레이아웃: 필터(좌측) + 목록(우측) */}
         <div className="flex flex-col lg:flex-row gap-6">
-          {/* 필터 영역 (모바일: 위, 데스크탑: 좌측) */}
+          {/* 필터 영역 */}
           <aside className="lg:w-80 flex-shrink-0">
-            <div className="sticky top-4">
+            <div className="lg:sticky lg:top-4">
               <AnimalFilters filters={filters} onFilterChange={handleFilterChange} />
             </div>
           </aside>
 
           {/* 동물 목록 영역 */}
-          <main className="flex-1">
+          <main className="flex-1 min-w-0">
             {/* 결과 요약 */}
-            <div className="mb-6">
+            <div className="mb-6 flex items-center justify-between">
               <p className="text-gray-600">
-                총 <span className="font-bold text-blue-600">{filteredAnimals.length}마리</span>의
-                동물을 찾았습니다
+                총 <span className="font-bold text-blue-600 text-lg">{filteredAnimals.length}마리</span>의
+                동물 친구를 찾았습니다
               </p>
+              {searchQuery && (
+                <div className="flex items-center gap-2 text-sm text-gray-500">
+                  <span>검색:</span>
+                  <span className="px-3 py-1 bg-blue-100 text-blue-700 rounded-full font-semibold">
+                    {searchQuery}
+                  </span>
+                </div>
+              )}
             </div>
 
             {/* 동물 카드 그리드 */}
             {filteredAnimals.length === 0 ? (
-              <div className="bg-white rounded-2xl shadow-md p-12 text-center">
-                <div className="text-6xl mb-4">😢</div>
-                <h3 className="text-xl font-bold text-gray-800 mb-2">
+              <div className="bg-white rounded-2xl shadow-md p-16 text-center transform hover:scale-105 transition-transform">
+                <div className="text-7xl mb-6 animate-bounce">😢</div>
+                <h3 className="text-2xl font-bold text-gray-800 mb-3">
                   검색 결과가 없습니다
                 </h3>
-                <p className="text-gray-600">
+                <p className="text-gray-600 mb-6">
                   다른 검색어나 필터를 시도해보세요
                 </p>
+                <button
+                  onClick={() => {
+                    setSearchQuery('');
+                    handleFilterChange('species', '');
+                    handleFilterChange('gender', '');
+                    handleFilterChange('status', '');
+                    handleFilterChange('region', '');
+                  }}
+                  className="px-6 py-3 bg-blue-500 text-white font-semibold rounded-xl hover:bg-blue-600 transition-colors"
+                >
+                  필터 초기화
+                </button>
               </div>
             ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 animate-fade-in">
                 {filteredAnimals.map((animal) => (
                   <AnimalCard
                     key={animal.id}

--- a/src/pages/Animals.tsx
+++ b/src/pages/Animals.tsx
@@ -1,9 +1,13 @@
 import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getAnimals } from '../api/animals.api';
+import { getMockAnimals } from '../api/animals.api.mock';
 import SearchBar from '../components/common/SearchBar';
 import AnimalFilters from '../components/common/AnimalFilters';
 import AnimalCard from '../components/common/AnimalCard';
+
+// 개발 환경에서는 Mock 데이터 사용
+const USE_MOCK_DATA = true; // 백엔드 연동 시 false로 변경
 
 export default function Animals() {
   // 검색어 상태
@@ -17,10 +21,10 @@ export default function Animals() {
     sortBy: 'latest',
   });
 
-  // 데이터 가져오기
+  // 데이터 가져오기 (Mock 또는 실제 API)
   const { data: animals, isLoading, error } = useQuery({
     queryKey: ['animals'],
-    queryFn: getAnimals,
+    queryFn: USE_MOCK_DATA ? getMockAnimals : getAnimals,
   });
 
   // 필터 변경 핸들러

--- a/src/pages/Animals.tsx
+++ b/src/pages/Animals.tsx
@@ -1,90 +1,211 @@
+import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getAnimals } from '../api/animals.api.ts';
+import { getAnimals } from '../api/animals.api';
+import SearchBar from '../components/common/SearchBar';
+import AnimalFilters from '../components/common/AnimalFilters';
+import AnimalCard from '../components/common/AnimalCard';
 
 export default function Animals() {
-  // useQuery로 데이터 가져오기
-  const { data: animals, isLoading, error } = useQuery({
-    queryKey: ['animals'],  // 캐시 키 (고유 식별자)
-    queryFn: getAnimals,    // 실제 API 호출 함수
+  // 검색어 상태
+  const [searchQuery, setSearchQuery] = useState('');
+  
+  // 필터 상태
+  const [filters, setFilters] = useState({
+    species: '',
+    gender: '',
+    status: '',
+    sortBy: 'latest',
   });
 
-  // 로딩 중
+  // 데이터 가져오기
+  const { data: animals, isLoading, error } = useQuery({
+    queryKey: ['animals'],
+    queryFn: getAnimals,
+  });
+
+  // 필터 변경 핸들러
+  const handleFilterChange = (key: string, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  // 검색 핸들러
+  const handleSearch = (query: string) => {
+    setSearchQuery(query);
+  };
+
+  // 찜하기 핸들러 (나중에 API 연동)
+  const handleFavorite = (id: number) => {
+    console.log('찜하기:', id);
+    // TODO: API 연동
+  };
+
+  // 필터링 및 정렬 로직
+  const filteredAnimals = useMemo(() => {
+    if (!animals) return [];
+
+    let result = [...animals];
+
+    // 검색 필터
+    if (searchQuery) {
+      result = result.filter((animal) =>
+        animal.name.toLowerCase().includes(searchQuery.toLowerCase())
+      );
+    }
+
+    // 종류 필터
+    if (filters.species) {
+      result = result.filter((animal) => animal.species === filters.species);
+    }
+
+    // 성별 필터
+    if (filters.gender) {
+      result = result.filter((animal) => animal.gender === filters.gender);
+    }
+
+    // 입양 상태 필터
+    if (filters.status) {
+      result = result.filter((animal) => animal.status === filters.status);
+    }
+
+    // 정렬
+    switch (filters.sortBy) {
+      case 'latest':
+        // 최신순 (ID 역순)
+        result.sort((a, b) => b.id - a.id);
+        break;
+      case 'name':
+        // 이름순
+        result.sort((a, b) => a.name.localeCompare(b.name));
+        break;
+      case 'age':
+        // 나이순
+        result.sort((a, b) => a.age - b.age);
+        break;
+    }
+
+    return result;
+  }, [animals, searchQuery, filters]);
+
+  // 로딩 상태
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
-          <p className="mt-4 text-gray-600">동물 목록을 불러오는 중...</p>
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white">
+        <div className="max-w-7xl mx-auto px-4 py-12">
+          <div className="flex flex-col items-center justify-center min-h-[400px]">
+            <div className="relative">
+              <div className="w-16 h-16 border-4 border-blue-200 border-t-blue-500 rounded-full animate-spin"></div>
+            </div>
+            <p className="mt-6 text-lg text-gray-600 font-medium">
+              동물 친구들을 불러오고 있어요...
+            </p>
+          </div>
         </div>
       </div>
     );
   }
 
-  // 에러 발생
+  // 에러 상태
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
-        <div className="bg-red-50 border border-red-200 rounded-lg p-6 max-w-md">
-          <h2 className="text-xl font-bold text-red-800 mb-2">
-            에러가 발생했습니다
-          </h2>
-          <p className="text-red-600">
-            {error instanceof Error ? error.message : '알 수 없는 에러'}
-          </p>
-          <p className="text-sm text-gray-600 mt-4">
-            💡 백엔드 서버가 실행 중인지 확인하세요
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  // 데이터 없음
-  if (!animals || animals.length === 0) {
-    return (
-      <div className="min-h-screen bg-gray-50 p-8">
-        <div className="max-w-6xl mx-auto text-center">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">
-            동물 목록
-          </h1>
-          <p className="text-gray-600">
-            현재 등록된 동물이 없습니다
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  // 데이터 표시
-  return (
-    <div className="min-h-screen bg-gray-50 p-8">
-      <div className="max-w-6xl mx-auto">
-        <h1 className="text-4xl font-bold text-gray-900 mb-8">
-          동물 목록
-        </h1>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {animals.map((animal) => (
-            <div 
-              key={animal.id} 
-              className="bg-white rounded-xl shadow-md p-6 hover:shadow-xl transition-shadow"
-            >
-              <div className="w-full h-48 bg-gray-200 rounded-lg mb-4 flex items-center justify-center">
-                <span className="text-4xl">{animal.species === '강아지' ? '🐕' : '🐈'}</span>
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white">
+        <div className="max-w-7xl mx-auto px-4 py-12">
+          <div className="flex items-center justify-center min-h-[400px]">
+            <div className="bg-white rounded-2xl shadow-xl p-8 max-w-md text-center">
+              <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg
+                  className="w-8 h-8 text-red-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                  />
+                </svg>
               </div>
-              <h3 className="text-xl font-bold mb-2">{animal.name}</h3>
-              <p className="text-gray-600 text-sm mb-1">품종: {animal.breed}</p>
-              <p className="text-gray-600 text-sm mb-1">나이: {animal.age}살</p>
-              <p className="text-gray-600 text-sm mb-3">성별: {animal.gender === 'MALE' ? '수컷' : '암컷'}</p>
-              <span className={`inline-block px-3 py-1 rounded-full text-sm font-semibold ${
-                animal.status === 'AVAILABLE' 
-                  ? 'bg-green-100 text-green-800' 
-                  : 'bg-gray-100 text-gray-800'
-              }`}>
-                {animal.status === 'AVAILABLE' ? '입양 가능' : '입양 완료'}
-              </span>
+              <h2 className="text-2xl font-bold text-gray-800 mb-2">
+                에러가 발생했습니다
+              </h2>
+              <p className="text-gray-600 mb-4">
+                {error instanceof Error ? error.message : '알 수 없는 에러'}
+              </p>
+              <p className="text-sm text-gray-500">
+                💡 백엔드 서버가 실행 중인지 확인해주세요
+              </p>
             </div>
-          ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 메인 UI
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-white">
+      <div className="max-w-7xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
+        {/* 헤더 */}
+        <div className="mb-8">
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-800 mb-3">
+            🐾 새 가족을 찾아요
+          </h1>
+          <p className="text-lg text-gray-600">
+            소중한 인연을 기다리는 동물 친구들입니다
+          </p>
+        </div>
+
+        {/* 검색바 */}
+        <div className="mb-6">
+          <SearchBar
+            onSearch={handleSearch}
+            placeholder="동물 이름으로 검색..."
+          />
+        </div>
+
+        {/* 레이아웃: 필터(좌측) + 목록(우측) */}
+        <div className="flex flex-col lg:flex-row gap-6">
+          {/* 필터 영역 (모바일: 위, 데스크탑: 좌측) */}
+          <aside className="lg:w-80 flex-shrink-0">
+            <div className="sticky top-4">
+              <AnimalFilters filters={filters} onFilterChange={handleFilterChange} />
+            </div>
+          </aside>
+
+          {/* 동물 목록 영역 */}
+          <main className="flex-1">
+            {/* 결과 요약 */}
+            <div className="mb-6">
+              <p className="text-gray-600">
+                총 <span className="font-bold text-blue-600">{filteredAnimals.length}마리</span>의
+                동물을 찾았습니다
+              </p>
+            </div>
+
+            {/* 동물 카드 그리드 */}
+            {filteredAnimals.length === 0 ? (
+              <div className="bg-white rounded-2xl shadow-md p-12 text-center">
+                <div className="text-6xl mb-4">😢</div>
+                <h3 className="text-xl font-bold text-gray-800 mb-2">
+                  검색 결과가 없습니다
+                </h3>
+                <p className="text-gray-600">
+                  다른 검색어나 필터를 시도해보세요
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+                {filteredAnimals.map((animal) => (
+                  <AnimalCard
+                    key={animal.id}
+                    animal={animal}
+                    onFavorite={handleFavorite}
+                  />
+                ))}
+              </div>
+            )}
+          </main>
         </div>
       </div>
     </div>

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -35,7 +35,7 @@ export interface ApiResponse<T> {
     userType: 'GENERAL' | 'SHELTER';
   }
   
-  // 동물 정보 (나중에 추가)
+  // 동물 정보
   export interface Animal {
     id: number;
     name: string;
@@ -45,4 +45,16 @@ export interface ApiResponse<T> {
     gender: 'MALE' | 'FEMALE';
     imageUrl: string;
     status: 'AVAILABLE' | 'ADOPTED';
+    // APMS 공공데이터 정보
+    noticeNo?: string;           // 공고번호
+    noticeStartDate?: string;    // 공고 시작일
+    noticeEndDate?: string;      // 공고 종료일
+    region?: string;             // 지역 (시/도)
+    city?: string;               // 시/군/구
+    foundPlace?: string;         // 발견 장소
+    shelterName?: string;        // 보호소 이름
+    weight?: string;             // 체중
+    color?: string;              // 색상
+    neutered?: boolean;          // 중성화 여부
+    description?: string;        // 특징 및 설명
   }


### PR DESCRIPTION
Closes #1

## 변경사항
- 동물 조회/검색 페이지 구현
- APMS 공공데이터 구조 반영
- 검색 및 필터 기능 (지역, 종류, 성별, 상태)
- 공고 종료 임박순 정렬 (기본값)
- 동물 카드 디자인 (D-day 배지, 위치 정보, 애니메이션)
- Mock 데이터 15마리
- 반응형 디자인

## 미구현
- 찜하기 API 연동 (UI만)
- 동물 상세 페이지
- 페이지네이션