### PR TITLE
feat: 로그인/회원가입/비밀번호 찾기 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { Routes, Route } from 'react-router-dom';
 import { useAuthStore } from './store/authStore.ts';
 import Home from './pages/Home.tsx';
 import Login from './pages/Login.tsx';
+import Signup from './pages/Signup.tsx';
+import ResetPassword from './pages/ResetPassword.tsx';
 import Animals from './pages/Animals.tsx';
 import AnimalDetail from './pages/AnimalDetail.tsx';
 import NotFound from './pages/NotFound.tsx';
@@ -16,6 +18,8 @@ function App() {
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/login" element={<Login />} />
+      <Route path="/signup" element={<Signup />} />
+      <Route path="/reset-password" element={<ResetPassword />} />
       <Route path="/animals" element={<Animals />} />
       <Route path="/animals/:id" element={<AnimalDetail />} />
       <Route path="*" element={<NotFound />} />

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -3,23 +3,30 @@ import type {
   ApiResponse, 
   LoginRequest, 
   LoginResponse, 
-  SignupRequest, 
+  SignupRequest,
+  SignupResponse,
+  ResetPasswordRequestRequest,
+  ResetPasswordRequest,
   User 
 } from '../types/api.types.ts';
 
 // 로그인
 export const login = async (credentials: LoginRequest): Promise<LoginResponse> => {
-  const response = await apiClient.post<ApiResponse<LoginResponse>>(
-    '/auth/login',
+  const response = await apiClient.post<LoginResponse>(
+    '/login',
     credentials
   );
-  return response.data.data;
+  return response.data;
 };
 
 // 회원가입
-export const signup = async (userData: SignupRequest): Promise<User> => {
-  const response = await apiClient.post<ApiResponse<User>>(
-    '/auth/signup',
+export const signup = async (userData: SignupRequest): Promise<SignupResponse> => {
+  const response = await apiClient.post<{
+    code: number;
+    message: string;
+    data: SignupResponse;
+  }>(
+    '/api/v1/users/signup',
     userData
   );
   return response.data.data;
@@ -36,4 +43,28 @@ export const logout = async (): Promise<void> => {
 export const getMyInfo = async (): Promise<User> => {
   const response = await apiClient.get<ApiResponse<User>>('/users/me');
   return response.data.data;
+};
+
+// 비밀번호 재설정 - 1단계: 인증 코드 발송
+export const sendResetCode = async (data: ResetPasswordRequestRequest): Promise<void> => {
+  await apiClient.post<{
+    code: number;
+    message: string;
+    data: null;
+  }>(
+    '/api/v1/auth/password/reset-request',
+    data
+  );
+};
+
+// 비밀번호 재설정 - 2단계: 인증 및 비밀번호 변경
+export const resetPassword = async (data: ResetPasswordRequest): Promise<void> => {
+  await apiClient.post<{
+    code: number;
+    message: string;
+    data: null;
+  }>(
+    '/api/v1/auth/password/reset',
+    data
+  );
 };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -46,11 +46,20 @@ export default function Header() {
             </Link>
           </nav>
 
-          {/* 로그인 버튼 & 모바일 메뉴 */}
-          <div className="flex items-center gap-4">
-            <button className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-primary text-primary-content text-sm font-bold leading-normal tracking-[0.015em] hover:opacity-90 transition-opacity">
+          {/* 로그인/회원가입 버튼 & 모바일 메뉴 */}
+          <div className="flex items-center gap-2 sm:gap-4">
+            <Link
+              to="/login"
+              className="hidden sm:flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-white dark:bg-gray-700 text-primary dark:text-primary text-sm font-bold leading-normal tracking-[0.015em] hover:opacity-90 transition-opacity border border-primary"
+            >
               <span className="truncate">로그인</span>
-            </button>
+            </Link>
+            <Link
+              to="/signup"
+              className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-primary text-white text-sm font-bold leading-normal tracking-[0.015em] hover:opacity-90 transition-opacity"
+            >
+              <span className="truncate">회원가입</span>
+            </Link>
             <button
               className="md:hidden text-primary-content dark:text-white"
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
@@ -94,6 +103,15 @@ export default function Header() {
               >
                 상점
               </Link>
+              <div className="pt-2 border-t border-primary/20 sm:hidden">
+                <Link
+                  to="/login"
+                  className="block text-primary-content dark:text-gray-300 text-sm font-medium hover:text-primary dark:hover:text-primary transition-colors"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  로그인
+                </Link>
+              </div>
             </div>
           </nav>
         )}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,23 +1,28 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
-import { login } from '../api/auth.api.ts';
-import { useAuthStore } from '../store/authStore.ts';  // 추가!
+import { login } from '../api/auth.api';
+import { useAuthStore } from '../store/authStore';
 
 export default function Login() {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  
-  // Zustand store 사용
-  const setAuth = useAuthStore((state) => state.setAuth);  // 추가!
+  const [showPassword, setShowPassword] = useState(false);
+
+  const setAuth = useAuthStore((state) => state.setAuth);
 
   const loginMutation = useMutation({
     mutationFn: login,
     onSuccess: (data) => {
-      // ✅ Zustand에 저장 (localStorage에도 자동 저장됨)
-      setAuth(data.user, data.accessToken, data.refreshToken);
-      
+      const user = {
+        id: data.userId,
+        email: data.email,
+        name: data.name,
+        userType: 'GENERAL' as const,
+        createdAt: new Date().toISOString(),
+      };
+      setAuth(user, data.accessToken, data.refreshToken);
       alert('로그인 성공!');
       navigate('/');
     },
@@ -32,57 +37,140 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
-      <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">
-          로그인
-        </h1>
-
-        {loginMutation.isError && (
-          <div className="mb-4 p-3 bg-red-100 text-red-700 rounded">
-            로그인에 실패했습니다
-          </div>
-        )}
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              이메일
-            </label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              placeholder="your@email.com"
-              required
-              disabled={loginMutation.isPending}
+    <div className="relative flex min-h-screen w-full items-center justify-center p-4 bg-background-light dark:bg-background-dark">
+      <div className="flex h-full w-full max-w-5xl overflow-hidden rounded-xl bg-white dark:bg-gray-900 shadow-lg border border-gray-200 dark:border-gray-700">
+        {/* Left Side - Image & Welcome Message */}
+        <div className="hidden lg:flex lg:w-1/2 flex-col items-center justify-center bg-emerald-200/50 dark:bg-gray-800 p-12">
+          <div className="flex flex-col items-center text-center gap-6">
+            <img
+              src="https://lh3.googleusercontent.com/aida-public/AB6AXuCvVy0FVCRXUdSS1RMfqcRZOpupHqPdWMGTlsGKB-sEfuo-bTI7QI5lllkGy__chxfvNt4DFcyA3Ixmoi8rWp_JsFfSLOVPTfBXvC53-AbyRIjyOt98RkWW9mvY1ZCbhgeR9McROS520VWyxIi0CZgZpk5ooy15zMqvvJRg64a43gZA-b6udBnKWRgbAEds9Qm5YgGypudMo32-IhafKYW7PCsC-Az_LrdiYhjengwROMo9LB7xnbONL9P38Jz2eUiAQMoIPrkkxb0"
+              alt="A person gently holding a small dog, symbolizing care and adoption"
+              className="w-40 h-40 rounded-full object-cover mb-4"
             />
+            <h1 className="text-3xl font-bold leading-tight tracking-tight text-emerald-600 dark:text-primary">
+              세상의 모든 동물이<br />행복해지는 그날까지
+            </h1>
+            <p className="text-base font-normal leading-relaxed text-gray-600 dark:text-gray-400">
+              유기동물을 위한 따뜻한 커뮤니티에<br />오신 것을 환영합니다.
+            </p>
           </div>
+        </div>
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              비밀번호
-            </label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              placeholder="********"
-              required
-              disabled={loginMutation.isPending}
-            />
+        {/* Right Side - Login Form */}
+        <div className="w-full lg:w-1/2 p-6 sm:p-10 md:p-12 flex items-center justify-center">
+          <div className="w-full max-w-sm mx-auto">
+            <div className="pb-3 mb-6">
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white">로그인</h2>
+            </div>
+
+            <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+              <div className="flex flex-col gap-4">
+                {/* Email Input */}
+                <label className="flex flex-col w-full">
+                  <p className="text-gray-900 dark:text-gray-200 text-sm font-medium leading-normal pb-2">
+                    이메일
+                  </p>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="form-input w-full rounded-md text-gray-900 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-primary border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 h-12 placeholder:text-gray-500 dark:placeholder:text-gray-500 px-4 text-sm font-normal leading-normal"
+                    placeholder="이메일 주소를 입력하세요"
+                    required
+                    disabled={loginMutation.isPending}
+                  />
+                </label>
+
+                {/* Password Input */}
+                <label className="flex flex-col w-full">
+                  <p className="text-gray-900 dark:text-gray-200 text-sm font-medium leading-normal pb-2">
+                    비밀번호
+                  </p>
+                  <div className="relative w-full h-12">
+                    <input
+                      type={showPassword ? 'text' : 'password'}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      className="form-input w-full h-full rounded-md text-gray-900 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-primary border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 placeholder:text-gray-500 dark:placeholder:text-gray-500 px-4 pr-10 text-sm font-normal leading-normal"
+                      placeholder="비밀번호를 입력하세요"
+                      required
+                      disabled={loginMutation.isPending}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 dark:text-gray-400"
+                      aria-label="비밀번호 보기"
+                    >
+                      <span className="material-symbols-outlined text-xl">
+                        {showPassword ? 'visibility' : 'visibility_off'}
+                      </span>
+                    </button>
+                  </div>
+                </label>
+              </div>
+
+              {/* Forgot Password Link */}
+              <div className="flex justify-end">
+                <Link
+                  to="/reset-password"
+                  className="text-sm font-medium text-primary-dark hover:text-primary dark:text-primary dark:hover:text-primary-light"
+                >
+                  비밀번호 찾기
+                </Link>
+              </div>
+
+              {/* Login Button */}
+              <button
+                type="submit"
+                disabled={loginMutation.isPending}
+                className="flex min-w-[84px] w-full cursor-pointer items-center justify-center overflow-hidden rounded-md h-12 px-5 bg-primary text-white text-base font-bold leading-normal tracking-wide hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary dark:focus:ring-offset-gray-900 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <span className="truncate">
+                  {loginMutation.isPending ? '로그인 중...' : '로그인'}
+                </span>
+              </button>
+
+              {/* Divider */}
+              <div className="relative my-1">
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full border-t border-gray-200 dark:border-gray-600"></div>
+                </div>
+                <div className="relative flex justify-center">
+                  <span className="bg-white dark:bg-gray-900 px-2 text-sm text-gray-500 dark:text-gray-400">
+                    또는
+                  </span>
+                </div>
+              </div>
+
+              {/* Google Login Button */}
+              <button
+                type="button"
+                className="flex items-center justify-center gap-2 w-full h-12 px-4 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors duration-200"
+              >
+                <img
+                  src="https://lh3.googleusercontent.com/COxitqgJr1sJnIDe8-jiKhxDx1FrYbtRHKJ9z_hELisAlapwE9LUPh6fcXIfb5vwpbMl4xl9H9TRFPc5NOO8Sb3VSgIBrfRYvW6cUA"
+                  alt="Google logo"
+                  className="h-5 w-5"
+                />
+                <span className="text-sm font-semibold text-gray-900 dark:text-gray-200">
+                  구글로 로그인
+                </span>
+              </button>
+
+              {/* Signup Link */}
+              <p className="text-center text-sm text-gray-600 dark:text-gray-300">
+                아직 회원이 아니신가요?{' '}
+                <Link
+                  to="/signup"
+                  className="font-medium text-primary-dark hover:text-primary dark:text-primary dark:hover:text-primary-light"
+                >
+                  회원가입
+                </Link>
+              </p>
+            </form>
           </div>
-
-          <button
-            type="submit"
-            disabled={loginMutation.isPending}
-            className="w-full px-6 py-3 bg-blue-500 text-white rounded-lg font-semibold hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            {loginMutation.isPending ? '로그인 중...' : '로그인'}
-          </button>
-        </form>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,339 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { sendResetCode, resetPassword } from '../api/auth.api';
+
+export default function ResetPassword() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<1 | 2>(1);
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState(['', '', '', '', '', '']);
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [errors, setErrors] = useState<{ [key: string]: string }>({});
+
+  // 1단계: 인증 코드 발송
+  const sendCodeMutation = useMutation({
+    mutationFn: sendResetCode,
+    onSuccess: () => {
+      alert('인증 코드가 이메일로 발송되었습니다.');
+      setStep(2);
+    },
+    onError: (error: any) => {
+      const message = error.response?.data?.message || '인증 코드 발송에 실패했습니다';
+      alert(message);
+    },
+  });
+
+  // 2단계: 비밀번호 재설정
+  const resetPasswordMutation = useMutation({
+    mutationFn: resetPassword,
+    onSuccess: () => {
+      alert('비밀번호가 재설정되었습니다. 새로운 비밀번호로 로그인해주세요.');
+      navigate('/login');
+    },
+    onError: (error: any) => {
+      const message = error.response?.data?.message || '비밀번호 재설정에 실패했습니다';
+      alert(message);
+    },
+  });
+
+  // 이메일 검증
+  const validateEmail = (): boolean => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!email) {
+      setErrors({ email: '이메일을 입력하세요' });
+      return false;
+    }
+    if (!emailRegex.test(email)) {
+      setErrors({ email: '유효한 이메일 주소를 입력하세요' });
+      return false;
+    }
+    setErrors({});
+    return true;
+  };
+
+  // 비밀번호 규칙 검증
+  const validatePassword = (): boolean => {
+    const newErrors: { [key: string]: string } = {};
+
+    // 인증 코드 검증
+    const fullCode = code.join('');
+    if (fullCode.length !== 6) {
+      newErrors.code = '6자리 인증 코드를 입력하세요';
+    }
+
+    // 비밀번호 검증
+    if (!newPassword) {
+      newErrors.newPassword = '새 비밀번호를 입력하세요';
+    } else if (newPassword.length < 8 || newPassword.length > 20) {
+      newErrors.newPassword = '비밀번호는 8~20자여야 합니다';
+    } else {
+      // 영문, 숫자, 특수문자 모두 포함 확인
+      const hasLetter = /[a-zA-Z]/.test(newPassword);
+      const hasNumber = /\d/.test(newPassword);
+      const hasSpecial = /[@$!%*#?&]/.test(newPassword);
+      
+      if (!hasLetter || !hasNumber || !hasSpecial) {
+        newErrors.newPassword = '영문, 숫자, 특수문자(@$!%*#?&)를 모두 포함해야 합니다';
+      }
+    }
+
+    // 비밀번호 확인 검증
+    if (!confirmPassword) {
+      newErrors.confirmPassword = '비밀번호 확인을 입력하세요';
+    } else if (newPassword !== confirmPassword) {
+      newErrors.confirmPassword = '비밀번호가 일치하지 않습니다';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  // 1단계 제출
+  const handleStep1Submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (validateEmail()) {
+      sendCodeMutation.mutate({ email });
+    }
+  };
+
+  // 2단계 제출
+  const handleStep2Submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (validatePassword()) {
+      resetPasswordMutation.mutate({
+        email,
+        code: code.join(''),
+        newPassword,
+      });
+    }
+  };
+
+  // 인증 코드 재발송
+  const handleResendCode = () => {
+    sendCodeMutation.mutate({ email });
+  };
+
+  // 인증 코드 입력 처리
+  const handleCodeChange = (index: number, value: string) => {
+    if (value.length > 1) {
+      value = value[0];
+    }
+    
+    const newCode = [...code];
+    newCode[index] = value;
+    setCode(newCode);
+
+    // 자동 포커스 이동
+    if (value && index < 5) {
+      const nextInput = document.getElementById(`code-${index + 1}`);
+      nextInput?.focus();
+    }
+  };
+
+  // 백스페이스 처리
+  const handleCodeKeyDown = (index: number, e: React.KeyboardEvent) => {
+    if (e.key === 'Backspace' && !code[index] && index > 0) {
+      const prevInput = document.getElementById(`code-${index - 1}`);
+      prevInput?.focus();
+    } else if (e.key === 'ArrowLeft' && index > 0) {
+      const prevInput = document.getElementById(`code-${index - 1}`);
+      prevInput?.focus();
+    } else if (e.key === 'ArrowRight' && index < 5) {
+      const nextInput = document.getElementById(`code-${index + 1}`);
+      nextInput?.focus();
+    }
+  };
+
+  return (
+    <div className="relative flex min-h-screen w-full flex-col items-center justify-center p-4 bg-background-light dark:bg-background-dark">
+      <div className="w-full max-w-md rounded-xl border border-gray-200/50 dark:border-gray-700/50 bg-white dark:bg-gray-900 p-8 shadow-sm">
+        {step === 1 ? (
+          // 1단계: 이메일 입력
+          <div className="flex flex-col items-center">
+            <h1 className="text-gray-900 dark:text-white text-3xl font-bold tracking-tight text-center pb-3 pt-6">
+              비밀번호 찾기
+            </h1>
+            <p className="text-gray-900 dark:text-white text-base font-normal leading-normal text-center pb-8">
+              가입하신 이메일 주소를 입력하시면 인증 코드를 보내드립니다.
+            </p>
+            
+            <form onSubmit={handleStep1Submit} className="w-full">
+              <div className="flex flex-col gap-4 py-3">
+                <label className="flex flex-col w-full">
+                  <p className="text-gray-900 dark:text-white text-base font-medium leading-normal pb-2">
+                    이메일
+                  </p>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg border border-gray-300 bg-background-light dark:bg-gray-800 dark:border-gray-600 text-gray-900 dark:text-white h-14 p-[15px] text-base font-normal leading-normal placeholder:text-gray-500 dark:placeholder:text-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/20"
+                    placeholder="이메일 주소를 입력하세요"
+                    disabled={sendCodeMutation.isPending}
+                  />
+                  {errors.email && (
+                    <p className="mt-2 text-sm text-red-600 dark:text-red-500">{errors.email}</p>
+                  )}
+                </label>
+              </div>
+
+              <div className="flex py-3">
+                <button
+                  type="submit"
+                  disabled={sendCodeMutation.isPending}
+                  className="flex min-w-[84px] w-full cursor-pointer items-center justify-center overflow-hidden rounded-lg h-12 px-5 bg-primary text-white text-base font-bold leading-normal tracking-[0.015em] hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <span className="truncate">
+                    {sendCodeMutation.isPending ? '발송 중...' : '인증 코드 발송'}
+                  </span>
+                </button>
+              </div>
+            </form>
+
+            <Link
+              to="/login"
+              className="text-gray-600 dark:text-gray-400 text-sm font-normal leading-normal pt-6 pb-3 text-center underline hover:text-primary dark:hover:text-primary transition-colors"
+            >
+              로그인 페이지로 돌아가기
+            </Link>
+          </div>
+        ) : (
+          // 2단계: 인증 코드 & 비밀번호
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-2 text-center">
+              <h1 className="text-gray-900 dark:text-white text-3xl font-bold leading-tight tracking-tight">
+                비밀번호 재설정
+              </h1>
+              <p className="text-gray-600 dark:text-gray-400 text-base font-normal leading-normal">
+                {email}으로 인증 코드가 발송되었습니다.
+              </p>
+            </div>
+
+            <form onSubmit={handleStep2Submit} className="flex flex-col gap-6">
+              {/* 인증 코드 */}
+              <div className="flex flex-col gap-2">
+                <label className="text-gray-900 dark:text-white text-base font-medium leading-normal">
+                  인증 코드
+                </label>
+                <div className="flex justify-between gap-2">
+                  {code.map((digit, index) => (
+                    <input
+                      key={index}
+                      id={`code-${index}`}
+                      type="number"
+                      min="0"
+                      max="9"
+                      maxLength={1}
+                      value={digit}
+                      onChange={(e) => handleCodeChange(index, e.target.value)}
+                      onKeyDown={(e) => handleCodeKeyDown(index, e)}
+                      className="flex h-14 w-full text-center text-lg font-bold text-gray-900 dark:text-white bg-transparent border-0 border-b-2 border-gray-200 dark:border-gray-700 focus:border-primary focus:ring-0 focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                      disabled={resetPasswordMutation.isPending}
+                    />
+                  ))}
+                </div>
+                {errors.code && (
+                  <p className="mt-2 text-sm text-red-600 dark:text-red-500">{errors.code}</p>
+                )}
+              </div>
+
+              {/* 새 비밀번호 */}
+              <div className="flex flex-col gap-1">
+                <label className="flex flex-col w-full">
+                  <p className="text-gray-900 dark:text-white text-base font-medium leading-normal pb-2">
+                    새 비밀번호
+                  </p>
+                  <div className="flex w-full items-stretch rounded-lg">
+                    <input
+                      type={showNewPassword ? 'text' : 'password'}
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-gray-900 dark:text-white focus:outline-none focus:ring-0 focus:border-primary border border-gray-300 dark:border-gray-600 bg-background-light dark:bg-gray-800 h-14 placeholder:text-gray-400 p-[15px] rounded-r-none border-r-0 pr-2 text-base font-normal leading-normal"
+                      placeholder="새 비밀번호를 입력하세요"
+                      disabled={resetPasswordMutation.isPending}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowNewPassword(!showNewPassword)}
+                      className="text-gray-400 flex border border-gray-300 dark:border-gray-600 bg-background-light dark:bg-gray-800 items-center justify-center pr-[15px] rounded-r-lg border-l-0"
+                    >
+                      <span className="material-symbols-outlined text-2xl">
+                        {showNewPassword ? 'visibility' : 'visibility_off'}
+                      </span>
+                    </button>
+                  </div>
+                </label>
+                <p className="text-gray-600 dark:text-gray-400 text-sm font-normal leading-normal pt-1 px-1">
+                  8~20자 영문, 숫자, 특수문자를 조합하여 입력해주세요.
+                </p>
+                {errors.newPassword && (
+                  <p className="text-sm text-red-600 dark:text-red-500">{errors.newPassword}</p>
+                )}
+              </div>
+
+              {/* 비밀번호 확인 */}
+              <div className="flex flex-col gap-2">
+                <label className="flex flex-col w-full">
+                  <p className="text-gray-900 dark:text-white text-base font-medium leading-normal pb-2">
+                    비밀번호 확인
+                  </p>
+                  <div className="flex w-full items-stretch rounded-lg">
+                    <input
+                      type={showConfirmPassword ? 'text' : 'password'}
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-gray-900 dark:text-white focus:outline-none focus:ring-0 focus:border-primary border border-gray-300 dark:border-gray-600 bg-background-light dark:bg-gray-800 h-14 placeholder:text-gray-400 p-[15px] rounded-r-none border-r-0 pr-2 text-base font-normal leading-normal"
+                      placeholder="비밀번호를 다시 한번 입력하세요"
+                      disabled={resetPasswordMutation.isPending}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                      className="text-gray-400 flex border border-gray-300 dark:border-gray-600 bg-background-light dark:bg-gray-800 items-center justify-center pr-[15px] rounded-r-lg border-l-0"
+                    >
+                      <span className="material-symbols-outlined text-2xl">
+                        {showConfirmPassword ? 'visibility' : 'visibility_off'}
+                      </span>
+                    </button>
+                  </div>
+                </label>
+                {errors.confirmPassword && (
+                  <p className="mt-2 text-sm text-red-600 dark:text-red-500">{errors.confirmPassword}</p>
+                )}
+              </div>
+
+              {/* 제출 버튼 */}
+              <button
+                type="submit"
+                disabled={resetPasswordMutation.isPending}
+                className="flex items-center justify-center whitespace-nowrap h-12 px-6 rounded-lg w-full bg-primary text-white text-base font-bold leading-normal tracking-[-0.015em] hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {resetPasswordMutation.isPending ? '재설정 중...' : '비밀번호 재설정'}
+              </button>
+            </form>
+
+            {/* 재발송 링크 */}
+            <div className="text-center">
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                인증 코드를 받지 못하셨나요?{' '}
+                <button
+                  type="button"
+                  onClick={handleResendCode}
+                  disabled={sendCodeMutation.isPending}
+                  className="font-bold text-primary hover:underline disabled:opacity-50"
+                >
+                  다시 받기
+                </button>
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,0 +1,248 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { signup } from '../api/auth.api';
+import type { SignupRequest } from '../types/api.types';
+
+export default function Signup() {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState<SignupRequest>({
+    email: '',
+    name: '',
+    password: '',
+    rePassword: '',
+    userType: 'GENERAL',
+  });
+  const [errors, setErrors] = useState<Partial<Record<keyof SignupRequest, string>>>({});
+
+  const signupMutation = useMutation({
+    mutationFn: signup,
+    onSuccess: (data) => {
+      alert(`회원가입 성공!\n환영합니다, ${data.name}님!`);
+      navigate('/login');
+    },
+    onError: (error: any) => {
+      const message = error.response?.data?.message || '회원가입에 실패했습니다';
+      alert(message);
+    },
+  });
+
+  const validateForm = (): boolean => {
+    const newErrors: Partial<Record<keyof SignupRequest, string>> = {};
+
+    // 이메일 검증
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!formData.email) {
+      newErrors.email = '이메일을 입력하세요';
+    } else if (!emailRegex.test(formData.email)) {
+      newErrors.email = '유효한 이메일 주소를 입력하세요';
+    }
+
+    // 이름 검증
+    if (!formData.name) {
+      newErrors.name = '이름을 입력하세요';
+    } else if (formData.name.length > 20) {
+      newErrors.name = '이름은 최대 20자까지 입력 가능합니다';
+    }
+
+    // 비밀번호 검증
+    if (!formData.password) {
+      newErrors.password = '비밀번호를 입력하세요';
+    } else if (formData.password.length < 6) {
+      newErrors.password = '비밀번호는 최소 6자 이상이어야 합니다';
+    }
+
+    // 비밀번호 확인 검증
+    if (!formData.rePassword) {
+      newErrors.rePassword = '비밀번호 확인을 입력하세요';
+    } else if (formData.password !== formData.rePassword) {
+      newErrors.rePassword = '비밀번호가 일치하지 않습니다';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleChange = (field: keyof SignupRequest, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    // 입력 시 해당 필드 에러 제거
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: undefined }));
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (validateForm()) {
+      signupMutation.mutate(formData);
+    }
+  };
+
+  return (
+    <div className="relative flex min-h-screen w-full flex-col items-center justify-center p-4 sm:p-6 lg:p-8 bg-background-light dark:bg-background-dark">
+      <div className="w-full max-w-lg space-y-8">
+        {/* Page Heading */}
+        <div className="text-center">
+          <h1 className="text-3xl font-black tracking-tighter text-gray-900 dark:text-white sm:text-4xl">
+            회원가입
+          </h1>
+        </div>
+
+        {/* Form Container */}
+        <div className="rounded-xl border border-gray-200/50 bg-white/50 p-6 shadow-sm dark:border-gray-700/50 dark:bg-gray-900/50 sm:p-8">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* User Type Selection */}
+            <div>
+              <p className="mb-3 text-base font-medium text-gray-900 dark:text-gray-100">
+                회원 유형
+              </p>
+              <div className="grid grid-cols-2 gap-4">
+                <label className="flex cursor-pointer items-center justify-center rounded-lg border border-gray-300 bg-white p-4 text-center text-gray-700 has-[:checked]:border-primary has-[:checked]:bg-primary/10 has-[:checked]:text-primary dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:has-[:checked]:border-primary dark:has-[:checked]:bg-primary/20 dark:has-[:checked]:text-primary">
+                  <input
+                    type="radio"
+                    name="userType"
+                    value="GENERAL"
+                    checked={formData.userType === 'GENERAL'}
+                    onChange={(e) => handleChange('userType', e.target.value)}
+                    className="sr-only"
+                  />
+                  <span>일반 회원</span>
+                </label>
+                <label className="flex cursor-pointer items-center justify-center rounded-lg border border-gray-300 bg-white p-4 text-center text-gray-700 has-[:checked]:border-primary has-[:checked]:bg-primary/10 has-[:checked]:text-primary dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:has-[:checked]:border-primary dark:has-[:checked]:bg-primary/20 dark:has-[:checked]:text-primary">
+                  <input
+                    type="radio"
+                    name="userType"
+                    value="SHELTER"
+                    checked={formData.userType === 'SHELTER'}
+                    onChange={(e) => handleChange('userType', e.target.value)}
+                    className="sr-only"
+                  />
+                  <span>보호소 회원</span>
+                </label>
+              </div>
+            </div>
+
+            {/* Email Field */}
+            <div className="space-y-2">
+              <label className="text-base font-medium text-gray-900 dark:text-gray-100" htmlFor="email">
+                이메일
+              </label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                value={formData.email}
+                onChange={(e) => handleChange('email', e.target.value)}
+                placeholder="이메일 주소를 입력하세요"
+                className={`block w-full rounded-lg border p-3.5 text-gray-900 placeholder:text-gray-500 focus:border-primary focus:ring-primary dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-400 sm:text-sm sm:leading-6 ${
+                  errors.email
+                    ? 'border-red-500 dark:border-red-500'
+                    : 'border-gray-300 dark:border-gray-600'
+                }`}
+                disabled={signupMutation.isPending}
+              />
+              {errors.email && (
+                <p className="mt-2 text-sm text-red-600 dark:text-red-500">{errors.email}</p>
+              )}
+            </div>
+
+            {/* Name Field */}
+            <div className="space-y-2">
+              <label className="text-base font-medium text-gray-900 dark:text-gray-100" htmlFor="name">
+                이름
+              </label>
+              <input
+                type="text"
+                id="name"
+                name="name"
+                value={formData.name}
+                onChange={(e) => handleChange('name', e.target.value)}
+                placeholder="이름을 입력하세요"
+                className={`block w-full rounded-lg border p-3.5 text-gray-900 placeholder:text-gray-500 focus:border-primary focus:ring-primary dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-400 sm:text-sm sm:leading-6 ${
+                  errors.name
+                    ? 'border-red-500 dark:border-red-500'
+                    : 'border-gray-300 dark:border-gray-600'
+                }`}
+                disabled={signupMutation.isPending}
+              />
+              {errors.name && (
+                <p className="mt-2 text-sm text-red-600 dark:text-red-500">{errors.name}</p>
+              )}
+            </div>
+
+            {/* Password Field */}
+            <div className="space-y-2">
+              <label className="text-base font-medium text-gray-900 dark:text-gray-100" htmlFor="password">
+                비밀번호
+              </label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                value={formData.password}
+                onChange={(e) => handleChange('password', e.target.value)}
+                placeholder="비밀번호를 입력하세요"
+                className={`block w-full rounded-lg border p-3.5 text-gray-900 placeholder:text-gray-500 focus:border-primary focus:ring-primary dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-400 sm:text-sm sm:leading-6 ${
+                  errors.password
+                    ? 'border-red-500 dark:border-red-500'
+                    : 'border-gray-300 dark:border-gray-600'
+                }`}
+                disabled={signupMutation.isPending}
+              />
+              {errors.password && (
+                <p className="mt-2 text-sm text-red-600 dark:text-red-500">{errors.password}</p>
+              )}
+            </div>
+
+            {/* Confirm Password Field */}
+            <div className="space-y-2">
+              <label className="text-base font-medium text-gray-900 dark:text-gray-100" htmlFor="rePassword">
+                비밀번호 확인
+              </label>
+              <input
+                type="password"
+                id="rePassword"
+                name="rePassword"
+                value={formData.rePassword}
+                onChange={(e) => handleChange('rePassword', e.target.value)}
+                placeholder="비밀번호를 다시 한번 입력하세요"
+                className={`block w-full rounded-lg border p-3.5 text-gray-900 placeholder:text-gray-500 focus:border-primary focus:ring-primary dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-400 sm:text-sm sm:leading-6 ${
+                  errors.rePassword
+                    ? 'border-red-500 dark:border-red-500'
+                    : 'border-gray-300 dark:border-gray-600'
+                }`}
+                disabled={signupMutation.isPending}
+              />
+              {errors.rePassword && (
+                <p className="mt-2 text-sm text-red-600 dark:text-red-500">{errors.rePassword}</p>
+              )}
+            </div>
+
+            {/* Submit Button */}
+            <div>
+              <button
+                type="submit"
+                disabled={signupMutation.isPending}
+                className="flex w-full justify-center rounded-lg bg-primary px-3 py-4 text-base font-bold leading-6 text-gray-900 shadow-sm transition-transform hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+              >
+                {signupMutation.isPending ? '처리 중...' : '회원가입 완료'}
+              </button>
+            </div>
+
+            {/* Login Link */}
+            <p className="text-center text-sm text-gray-600 dark:text-gray-300">
+              이미 회원이신가요?{' '}
+              <Link
+                to="/login"
+                className="font-medium text-primary-dark hover:text-primary dark:text-primary dark:hover:text-primary-light"
+              >
+                로그인
+              </Link>
+            </p>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -22,17 +22,40 @@ export interface LoginRequest {
 
 // 로그인 응답
 export interface LoginResponse {
+  userId: number;
+  email: string;
+  name: string;
   accessToken: string;
   refreshToken: string;
-  user: User;
 }
 
 // 회원가입 요청
 export interface SignupRequest {
   email: string;
-  password: string;
   name: string;
-  userType: 'GENERAL' | 'SHELTER';
+  password: string;
+  rePassword: string;
+  userType?: 'GENERAL' | 'SHELTER';
+}
+
+// 회원가입 응답
+export interface SignupResponse {
+  userId: number;
+  email: string;
+  name: string;
+  nickname: string;
+}
+
+// 비밀번호 재설정 - 1단계 요청 (인증 코드 발송)
+export interface ResetPasswordRequestRequest {
+  email: string;
+}
+
+// 비밀번호 재설정 - 2단계 요청 (인증 및 비밀번호 변경)
+export interface ResetPasswordRequest {
+  email: string;
+  code: string;
+  newPassword: string;
 }
 
 // 동물 상태 타입

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:9020',
         changeOrigin: true,
+      },
+      '/login': {
+        target: 'http://localhost:9020',
+        changeOrigin: true,
       }
     }
   }


### PR DESCRIPTION
## 목적
사용자 인증 시스템을 구현하고, 일반 회원과 보호소 회원을 구분하여 회원가입할 수 있는 페이지를 제공합니다. 기존 로그인 페이지를 새로운 디자인으로 리뉴얼하고, 비밀번호 찾기 기능을 추가하여 사용자 경험을 향상시킵니다.

## 작업 내용
- [x] 로그인 페이지 디자인 리뉴얼 (2-column 레이아웃)
- [x] 회원가입 페이지 신규 구현
- [x] 비밀번호 찾기 페이지 구현 (2단계 이메일 인증)
- [x] 폼 유효성 검증 (이메일, 비밀번호 규칙)
- [x] 일반 회원 / 보호소 회원 타입 선택
- [x] API 연동 (로그인, 회원가입, 비밀번호 재설정)
- [x] CORS 설정 (Vite proxy)
- [x] Header에 로그인/회원가입 버튼 추가
- [x] 반응형 디자인 적용

## 기술 구현
- 로그인: POST /login
- 회원가입: POST /api/v1/users/signup
- 비밀번호 재설정 (1단계): POST /api/v1/auth/password/reset-request
- 비밀번호 재설정 (2단계): POST /api/v1/auth/password/reset
- 비밀번호 규칙: 8~20자, 영문+숫자+특수문자 모두 포함
- 인증 코드 6자리 입력 (자동 포커스 이동)
- React Query로 API 상태 관리
- Zustand로 인증 상태 관리

## Closes
Closes #7 