### PR TITLE
[Hotfix] via.placeholder 오류 수정 및 실제 API 연결

### DIFF
--- a/src/components/common/AnimalCardSimple.tsx
+++ b/src/components/common/AnimalCardSimple.tsx
@@ -67,8 +67,8 @@ export default function AnimalCardSimple({ animal }: AnimalCardSimpleProps) {
   // 공고번호 (백엔드 필드명 apmsNoticeNo 우선)
   const noticeNumber = animal.apmsNoticeNo || animal.noticeNo;
 
-  // 이미지 URL (없으면 플레이스홀더)
-  const imageUrl = animal.imageUrl || `https://via.placeholder.com/400?text=${encodeURIComponent(animal.name)}`;
+  // 이미지 URL
+  const imageUrl = animal.imageUrl;
 
   return (
     <Link
@@ -76,16 +76,22 @@ export default function AnimalCardSimple({ animal }: AnimalCardSimpleProps) {
       className="flex flex-col bg-card-light dark:bg-card-dark rounded-xl overflow-hidden shadow-sm border border-border-light dark:border-border-dark transition-transform hover:-translate-y-1"
     >
       {/* 이미지 */}
-      <div className="aspect-square w-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
-        <img
-          src={imageUrl}
-          alt={animal.name}
-          className="w-full h-full object-cover transition-transform hover:scale-105 duration-300"
-          loading="lazy"
-          onError={(e) => {
-            (e.target as HTMLImageElement).src = `https://via.placeholder.com/400?text=${encodeURIComponent(animal.name)}`;
-          }}
-        />
+      <div className="aspect-square w-full bg-gray-100 dark:bg-gray-800 overflow-hidden relative">
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={animal.name}
+            className="w-full h-full object-cover transition-transform hover:scale-105 duration-300"
+            loading="lazy"
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = 'none';
+            }}
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-gray-200 to-gray-300 dark:from-gray-700 dark:to-gray-800">
+            <span className="text-gray-500 dark:text-gray-400 text-sm">이미지 없음</span>
+          </div>
+        )}
       </div>
 
       {/* 정보 */}

--- a/src/pages/AnimalDetail.tsx
+++ b/src/pages/AnimalDetail.tsx
@@ -67,7 +67,7 @@ export default function AnimalDetail() {
   const speciesLabel = animal.species === 'DOG' ? '개' : animal.species === 'CAT' ? '고양이' : '기타';
   
   // 메인 이미지 (선택된 이미지 또는 기본 이미지)
-  const mainImage = selectedImage || animal.imageUrl || `https://via.placeholder.com/800?text=${encodeURIComponent(animal.breed)}`;
+  const mainImage = selectedImage || animal.imageUrl || '';
   
   // 이미지 목록 (메인 + 추가 이미지)
   const images = [animal.imageUrl, animal.imageUrl2].filter(Boolean) as string[];
@@ -137,7 +137,7 @@ export default function AnimalDetail() {
                 alt={`${animal.breed} 메인 사진`}
                 className="w-full h-full object-contain"
                 onError={(e) => {
-                  (e.target as HTMLImageElement).src = `https://via.placeholder.com/800x600?text=${encodeURIComponent(animal.breed)}`;
+                  (e.target as HTMLImageElement).style.display = 'none';
                 }}
               />
             </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,16 @@
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { getMockAnimals } from '../api/animals.api.mock';
+import { getAnimals } from '../api/animals.api';
 import type { Animal } from '../types/api.types';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
 import AnimalCardSimple from '../components/common/AnimalCardSimple';
 
 export default function Home() {
-  // 동물 데이터 가져오기
+  // 동물 데이터 가져오기 (실제 백엔드 API)
   const { data } = useQuery({
-    queryKey: ['animals'],
-    queryFn: () => getMockAnimals(),
+    queryKey: ['featured-animals'],
+    queryFn: () => getAnimals({ page: 0, size: 4, sort: 'createdAt,desc', status: 'PROTECT' }),
   });
 
   // 최근 등록 동물 (4마리만)


### PR DESCRIPTION
## 개요
배포 환경에서 via.placeholder.com DNS 오류 발생하여 긴급 수정

## 수정 내역

### 1. 메인 페이지 실제 API 연결
- **Home.tsx**: Mock 데이터 제거, 실제 백엔드 API 호출
- Featured 동물: `GET /api/animals?page=0&size=4&status=PROTECT`

### 2. via.placeholder 제거
- **AnimalCardSimple.tsx**: 
  - 이미지 없을 때 "이미지 없음" 표시
  - via.placeholder 폴백 제거
- **AnimalDetail.tsx**: 
  - via.placeholder 폴백 제거
  - 이미지 로드 실패 시 숨김 처리

## 효과
- ✅ via.placeholder DNS 오류 해결
- ✅ 콘솔 에러 제거
- ✅ 메인 페이지 실제 데이터 표시

## 테스트
- ⏳ Vercel 재배포 후 확인 예정