### PR TITLE
hotfix: placeholder 이미지 로드 실패 시 로컬 대체 적용

### DIFF
--- a/src/assets/image-placeholder.svg
+++ b/src/assets/image-placeholder.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300" role="img" aria-labelledby="title desc">
+  <title id="title">이미지 준비 중</title>
+  <desc id="desc">상품 이미지를 불러올 수 없습니다</desc>
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#e5e7eb"/>
+      <stop offset="100%" stop-color="#d1d5db"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" fill="url(#g)"/>
+  <g fill="none" stroke="#9ca3af" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="80" y="70" width="240" height="170" rx="12" ry="12"/>
+    <path d="M120 190l55-60 45 52 30-36 30 44"/>
+    <circle cx="160" cy="120" r="18"/>
+  </g>
+  <text x="200" y="260" text-anchor="middle" font-family="sans-serif" font-size="18" fill="#6b7280">이미지를 불러올 수 없습니다</text>
+</svg>
+

--- a/src/components/common/ProductCard.tsx
+++ b/src/components/common/ProductCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import type { ProductListItem } from '../../types/api.types';
+import placeholderImg from '../../assets/image-placeholder.svg';
 
 interface ProductCardProps {
   product: ProductListItem;
@@ -24,6 +25,20 @@ export default function ProductCard({ product, onAddToCart }: ProductCardProps) 
     }
   };
 
+  const isBlockedPlaceholder = (url?: string) => {
+    if (!url) return true;
+    try {
+      const hostname = new URL(url).hostname;
+      return hostname.includes('placeholder.com');
+    } catch {
+      return true;
+    }
+  };
+
+  const resolvedImage = !isBlockedPlaceholder(product.imageUrl)
+    ? product.imageUrl
+    : placeholderImg;
+
   return (
     <Link
       to={`/products/${product.id}`}
@@ -31,14 +46,14 @@ export default function ProductCard({ product, onAddToCart }: ProductCardProps) 
     >
       {/* 이미지 */}
       <div className="relative">
-        {product.imageUrl ? (
+        {resolvedImage ? (
           <img
-            src={product.imageUrl}
+            src={resolvedImage}
             alt={product.name}
             className="h-56 w-full object-cover"
             loading="lazy"
             onError={(e) => {
-              (e.target as HTMLImageElement).style.display = 'none';
+              (e.target as HTMLImageElement).src = placeholderImg;
             }}
           />
         ) : (

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -5,6 +5,7 @@ import { getProductById, addToCart } from '../api/products.api';
 import type { ProductSku } from '../types/api.types';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
+import placeholderImg from '../assets/image-placeholder.svg';
 
 export default function ProductDetail() {
   const { id } = useParams<{ id: string }>();
@@ -176,6 +177,20 @@ export default function ProductDetail() {
     );
   }
 
+  const isBlockedPlaceholder = (url?: string) => {
+    if (!url) return true;
+    try {
+      const hostname = new URL(url).hostname;
+      return hostname.includes('placeholder.com');
+    } catch {
+      return true;
+    }
+  };
+
+  const resolvedMainImage = !isBlockedPlaceholder(mainImage || product.imageUrl)
+    ? (mainImage || product.imageUrl)
+    : placeholderImg;
+
   return (
     <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark">
       <Header />
@@ -187,13 +202,13 @@ export default function ProductDetail() {
             {/* 이미지 갤러리 */}
             <div className="flex flex-col gap-4">
               <div className="aspect-square w-full bg-gray-100 dark:bg-gray-800 rounded-xl overflow-hidden">
-                {(mainImage || product.imageUrl) ? (
+                {resolvedMainImage ? (
                   <img
-                    src={mainImage || product.imageUrl}
+                    src={resolvedMainImage}
                     alt={product.name}
                     className="w-full h-full object-cover"
                     onError={(e) => {
-                      (e.target as HTMLImageElement).style.display = 'none';
+                      (e.target as HTMLImageElement).src = placeholderImg;
                     }}
                   />
                 ) : (


### PR DESCRIPTION
## 요약
- 외부 placeholder.com 이미지가 차단될 때 로컬 플레이스홀더로 즉시 대체
- Product 카드/상세 이미지에 차단 호스트 감지 및 onError 대체 적용
- 로컬 SVG 플레이스홀더 추가