### PR TITLE
feat: 커뮤니티 및 입양 후기 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,14 @@ import Cart from './pages/Cart.tsx';
 import Checkout from './pages/Checkout.tsx';
 import OrderComplete from './pages/OrderComplete.tsx';
 import NotFound from './pages/NotFound.tsx';
+import CommunityList from './pages/CommunityList.tsx';
+import CommunityDetail from './pages/CommunityDetail.tsx';
+import CommunityCreate from './pages/CommunityCreate.tsx';
+import CommunityEdit from './pages/CommunityEdit.tsx';
+import AdoptionList from './pages/AdoptionList.tsx';
+import AdoptionDetail from './pages/AdoptionDetail.tsx';
+import AdoptionCreate from './pages/AdoptionCreate.tsx';
+import AdoptionEdit from './pages/AdoptionEdit.tsx';
 
 // 개발 환경에서만 window에 등록 (디버깅용)
 if (import.meta.env.DEV) {
@@ -104,6 +112,18 @@ function App() {
           </ProtectedRoute>
         }
       />
+      {/* 커뮤니티 (실종/보호/제보) */}
+      <Route path="/community" element={<CommunityList />} />
+      <Route path="/community/:id" element={<CommunityDetail />} />
+      {/* TODO: 임시로 ProtectedRoute 제거 - 페이지 확인용 */}
+      <Route path="/community/new" element={<CommunityCreate />} />
+      <Route path="/community/:id/edit" element={<CommunityEdit />} />
+      {/* 입양 후기 */}
+      <Route path="/adoption" element={<AdoptionList />} />
+      <Route path="/adoption/:id" element={<AdoptionDetail />} />
+      {/* TODO: 임시로 ProtectedRoute 제거 - 페이지 확인용 */}
+      <Route path="/adoption/new" element={<AdoptionCreate />} />
+      <Route path="/adoption/:id/edit" element={<AdoptionEdit />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -27,10 +27,10 @@ export default function Header() {
               동물 검색
             </Link>
             <Link
-              to="/reviews"
+              to="/adoption"
               className="text-primary-content dark:text-gray-300 text-sm font-medium leading-normal hover:text-primary dark:hover:text-primary transition-colors"
             >
-              입양 후기
+              입양후기
             </Link>
             <Link
               to="/community"
@@ -83,11 +83,11 @@ export default function Header() {
                 동물 검색
               </Link>
               <Link
-                to="/reviews"
+                to="/adoption"
                 className="text-primary-content dark:text-gray-300 text-sm font-medium hover:text-primary dark:hover:text-primary transition-colors"
                 onClick={() => setIsMobileMenuOpen(false)}
               >
-                입양 후기
+                입양후기
               </Link>
               <Link
                 to="/community"

--- a/src/pages/AdoptionCreate.tsx
+++ b/src/pages/AdoptionCreate.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import Header from '../components/layout/Header';
+
+export default function AdoptionCreate() {
+  const [form, setForm] = useState({
+    title: '',
+    content: '',
+    files: [] as File[],
+  });
+
+  return (
+    <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display text-gray-800 dark:text-gray-200">
+      <Header />
+      <main className="w-full max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <div className="flex flex-col gap-8">
+          <div className="p-4">
+            <p className="text-[#111816] dark:text-white text-4xl font-black leading-tight tracking-[-0.033em]">
+              입양후기 작성
+            </p>
+          </div>
+
+          <div className="space-y-8 p-4 bg-white dark:bg-[#1A2C28] rounded-xl shadow-sm">
+            <div className="flex flex-col">
+              <label className="flex flex-col min-w-40 flex-1">
+                <p className="text-[#111816] dark:text-gray-200 text-base font-medium leading-normal pb-2">제목 *</p>
+                <input
+                  className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#111816] dark:text-white focus:outline-0 focus:ring-2 focus:ring-primary focus:ring-opacity-50 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:border-primary h-14 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-[15px] text-base font-normal leading-normal"
+                  placeholder="소중한 가족이 된 아이의 이야기를 들려주세요."
+                  value={form.title}
+                  onChange={(e) => setForm({ ...form, title: e.target.value })}
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-col">
+              <label className="flex flex-col min-w-40 flex-1">
+                <p className="text-[#111816] dark:text-gray-200 text-base font-medium leading-normal pb-2">내용 *</p>
+                <textarea
+                  className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#111816] dark:text-white focus:outline-0 focus:ring-2 focus:ring-primary focus:ring-opacity-50 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:border-primary min-h-60 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-[15px] text-base font-normal leading-normal"
+                  placeholder="입양한 아이의 이름, 나이, 성격, 함께 지내며 있었던 행복한 순간들을 자유롭게 작성해주세요."
+                  value={form.content}
+                  onChange={(e) => setForm({ ...form, content: e.target.value })}
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-col p-4 bg-background-light dark:bg-background-dark rounded-lg">
+              <div className="flex flex-col items-center gap-6 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600 px-6 py-14">
+                <div className="flex max-w-[480px] flex-col items-center gap-2">
+                  <p className="text-[#111816] dark:text-white text-lg font-bold leading-tight tracking-[-0.015em] max-w-[480px] text-center">
+                    사진 첨부 (선택)
+                  </p>
+                  <p className="text-gray-600 dark:text-gray-400 text-sm font-normal leading-normal max-w-[480px] text-center">
+                    최대 10장까지 업로드할 수 있습니다.
+                  </p>
+                </div>
+                <button className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-gray-200 dark:bg-gray-700 text-[#111816] dark:text-white text-sm font-bold leading-normal tracking-[0.015em] hover:bg-gray-300 dark:hover:bg-gray-600">
+                  <span className="truncate">파일 선택</span>
+                </button>
+              </div>
+            </div>
+
+            <div className="flex justify-end items-center gap-4 p-4">
+              <Link
+                to="/adoption"
+                className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-12 px-6 bg-gray-200 dark:bg-gray-700 text-[#111816] dark:text-white text-base font-bold leading-normal tracking-[0.015em] hover:bg-gray-300 dark:hover:bg-gray-600"
+              >
+                <span className="truncate">취소</span>
+              </Link>
+              <button className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-12 px-6 bg-primary text-[#111816] text-base font-bold leading-normal tracking-[0.015em] hover:bg-opacity-80">
+                <span className="truncate">등록</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/AdoptionDetail.tsx
+++ b/src/pages/AdoptionDetail.tsx
@@ -1,0 +1,160 @@
+import { Link, useParams } from 'react-router-dom';
+import Header from '../components/layout/Header';
+import placeholderImg from '../assets/image-placeholder.svg';
+
+const mockAdoptionPost = {
+  postId: 1,
+  title: '우리집 복덩이, 사랑스러운 뭉치를 소개해요!',
+  content: `뭉치를 처음 만난 건 비가 오던 날이었어요. 작은 상자 안에서 떨고 있는 아이를 보고 그냥 지나칠 수가 없었죠. 처음에는 경계심이 많아 다가오지도 않던 아이가 이제는 제 껌딱지가 되었답니다.
+
+매일 아침 저를 깨워주고, 산책할 때 신나게 뛰어다니는 모습을 보면 저도 모르게 웃음이 나요. 뭉치 덕분에 저희 집에는 웃음꽃이 활짝 피었습니다. 사지 않고 입양하길 정말 잘했다는 생각이 듭니다. 유기동물 입양을 고민하시는 분들이 있다면, 망설이지 마세요. 아이들에게 따뜻한 가족이 되어주세요!`,
+  boardType: 'ADOPTION',
+  authorId: 123,
+  createdAt: '2024.07.15',
+  imageUrls: [
+    'https://lh3.googleusercontent.com/aida-public/AB6AXuCsRc9l2O17ADBABzPyWJoaaSwCJ4GB0cpKnZxJJJ60JVsZ3KAyzvzk4h4z9EmLuWbJlGk8ZiLay2ifp3ouA2Y3piy8oW-eCF6u6Su2KEwSzZvrZGr1Kq2LwkmSf9nxfW-hfgkeQy7NsAYqX5ewuueFqGdq3rfXGEu8MMCZttlLy_7DfEtNRFyPgZ9N6qy2mQPLZZ-wi8fZoelzTaH-1eCQd36qyGmHXxdzVbCeS-P0nHdYEyVrSxjRh_sqQkFW4PtxjcrLw6pVuBU',
+    'https://lh3.googleusercontent.com/aida-public/AB6AXuA1c62BLXJpx2qN_bOrDwzkyd5EzIFte-npX68Flx-_VjTsAZ2e2WzchvmtfISMoTlT8eKawVafhkD3E6MEmFrHMac7xD3XAERcVmMX5LAfgnWwXlQWeVPkgGUC98-UVeV2P7WhgY3-XzTn9-fXvJ9KpUreq-RuEyLlsBpPwNwcJfmsecTudekzIg8YZYgYo5SGrJ2evEzCk4LPFQctUhfUl9_ltyqD1JkPWselk4uPixmfws9glS09Ra53GAR5EVxgFAWZdxw1qwg',
+    'https://lh3.googleusercontent.com/aida-public/AB6AXuDUZBJ3AA1MT8_7kK1H6a44vgEm4XZp7jDBTAJVexzgL2YZdu1or1Iy1Sx7h6Atcm5vXGLaOcyvpzifLVsG4HQF5COXKjX1ZPh4uWuT7dtY9M-H2uITMAIA8HxNRy3VcqQiX2X6iiG_6ndjV_-ZGW7hmBZSPuzSnA9f92NYTfjhpAU0lwzPIJQ8Y3aovELFPqO3CjDUoXgkn3OM-NSUOSJ8B3MCfl0N47GlKU7Ke_FfzseeA_d62z5q88r7YfB6hR31zHH1Gm53Wfk',
+    'https://lh3.googleusercontent.com/aida-public/AB6AXuATVxU_x905oaEWE22ZPMQCFp5RmQZo6H-Y1m_T22GbiLD1eqMjUpyv_iVailxq9HNxJlctcFdrUH2XkCrunwYRTTqAp9QIbyPChUCih9PDb_V45gWNZgZl50vFt-ujhsxExql5n8UZ0NzhAWHG9D3TKV_w4iU0Qx3JpN-IGhaDo4RANl1F3hnSyiaYNtlpY4k9ckNlwtcGPe_o6XBBzb-GdfoaM6vxxFduSomhCMv1ScoenoK_stHELTVm1wmR7OPBeyltH6_aVJ8',
+  ],
+};
+
+const mockComments = [
+  {
+    commentId: 1,
+    authorId: 456,
+    authorName: 'petlover123',
+    content: '뭉치 너무 귀여워요! 좋은 가족 만나서 다행이네요. 항상 행복하세요!',
+    createdAt: '2024.07.16',
+    avatar: 'https://lh3.googleusercontent.com/aida-public/AB6AXuDr09dz-z9gZDnIud3imVS0mOVr2msYY8k5BJCi5BC6vfYCc83UbT-hzM9zqcYMb4sKNAln2-zXpGgX4X8x_dplZP_Ed3z3bBBrHoKgkoXi3F-hriTxVioSOefwSu9SY0T8mtPZUOLfr8QcvppYL7PQXPEGj9YTpS5oUE59FYS8pU18w0scP1ap8ajJutWYfrR82bED0tl-wBJJyxklXG5W7K4c8pSrj6mfMVKOZXZVPx-ZkqqUBaFfp-XVBE_Rj68U4TuAnpQuK_E',
+  },
+  {
+    commentId: 2,
+    authorId: 789,
+    authorName: 'angel_paws',
+    content: '정말 감동적인 이야기네요. 뭉치도, 작성자님도 꽃길만 걸으시길 바랍니다.',
+    createdAt: '2024.07.15',
+    avatar: 'https://lh3.googleusercontent.com/aida-public/AB6AXuAbuFN2N-AFKQV5ujFHl6PhWGc8PfPMmNn73KdemWNG8VOnovjMXbPInRB2BEJ0ZAcF9j-s-isHLTrDpMM9_dzaeM6KwztasBqfYFvQigsvF1wEvjDPjR_6_ONpjR4mN-W7t9s-Vu9lj6CfgJ6AyXrKcnGZ_fadNbphCeAJJdfEgzDR5tiT4162FFV0rXeTLKvrj7VVfx2CGtimELAKc21o9xbUwBjlK7eVcTZw2t_svy5fP50zCTt4ySeGnZ9V4wuzi9AOsPW-2D8',
+  },
+];
+
+export default function AdoptionDetail() {
+  const { id } = useParams<{ id: string }>();
+  const mainImage = mockAdoptionPost.imageUrls?.[0] || placeholderImg;
+  const thumbnails = mockAdoptionPost.imageUrls?.slice(1) || [];
+
+  return (
+    <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display text-[#111816] dark:text-gray-200">
+      <Header />
+      <main className="flex flex-1 justify-center py-10">
+        <div className="layout-content-container flex flex-col max-w-4xl flex-1 px-4">
+          {/* PageHeading */}
+          <div className="flex flex-col gap-3 p-4 border-b border-gray-200 dark:border-gray-800 pb-6 mb-6">
+            <div className="flex flex-wrap justify-between items-start gap-4">
+              <div className="flex flex-col gap-3">
+                <span className="inline-block bg-primary/20 text-primary-dark font-bold text-xs px-2 py-1 rounded-full w-fit">
+                  입양후기
+                </span>
+                <h1 className="text-[#111816] dark:text-white text-4xl font-black leading-tight tracking-[-0.033em]">
+                  {mockAdoptionPost.title}
+                </h1>
+              </div>
+              {/* ButtonGroup */}
+              <div className="flex-shrink-0">
+                <div className="flex gap-2">
+                  <Link
+                    to={`/adoption/${id}/edit`}
+                    className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-gray-200 dark:bg-gray-700 text-[#111816] dark:text-white text-sm font-bold leading-normal tracking-[0.015em] hover:bg-gray-300 dark:hover:bg-gray-600"
+                  >
+                    <span className="truncate">수정</span>
+                  </Link>
+                  <button className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-transparent text-gray-600 dark:text-gray-400 text-sm font-bold leading-normal tracking-[0.015em] hover:bg-gray-100 dark:hover:bg-gray-800">
+                    <span className="truncate">삭제</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+            {/* MetaText */}
+            <p className="text-gray-500 dark:text-gray-400 text-sm font-normal leading-normal pt-2">
+              작성자ID: user_{mockAdoptionPost.authorId} | 작성일: {mockAdoptionPost.createdAt}
+            </p>
+          </div>
+
+          {/* Carousel / Post Body */}
+          <div className="flex flex-col gap-8 px-4">
+            {/* Image Gallery */}
+            <div className="flex flex-col gap-4">
+              <div
+                className="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-xl bg-gray-200 dark:bg-gray-800"
+                style={{ backgroundImage: `url(${mainImage})` }}
+              />
+              {thumbnails.length > 0 && (
+                <div className="flex overflow-x-auto [-ms-scrollbar-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                  <div className="flex items-stretch p-1 gap-3">
+                    {thumbnails.map((url, idx) => (
+                      <div
+                        key={idx}
+                        className={`flex h-full flex-1 flex-col rounded-lg min-w-40 cursor-pointer ${
+                          idx === 0 ? 'border-2 border-primary' : 'opacity-60 hover:opacity-100 transition-opacity'
+                        }`}
+                      >
+                        <div
+                          className="w-full bg-center bg-no-repeat aspect-video bg-cover rounded-md"
+                          style={{ backgroundImage: `url(${url})` }}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Post Content */}
+            <div className="prose dark:prose-invert max-w-none text-gray-800 dark:text-gray-300 leading-relaxed">
+              <p className="whitespace-pre-line">{mockAdoptionPost.content}</p>
+            </div>
+          </div>
+
+          {/* Divider */}
+          <hr className="border-gray-200 dark:border-gray-800 my-12" />
+
+          {/* Comment Section */}
+          <div className="flex flex-col gap-8 px-4">
+            <h3 className="text-xl font-bold text-[#111816] dark:text-white">댓글</h3>
+
+            {/* Comment Form (Logged In) */}
+            <div className="flex flex-col gap-3">
+              <textarea
+                className="w-full p-3 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-gray-800 dark:text-gray-200 placeholder-gray-400"
+                placeholder="따뜻한 댓글을 남겨주세요..."
+                rows={4}
+              />
+              <button className="self-end flex min-w-[100px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-primary text-[#111816] text-sm font-bold leading-normal tracking-[0.015em] hover:opacity-90">
+                <span className="truncate">댓글 등록</span>
+              </button>
+            </div>
+
+            {/* Comment List */}
+            <div className="flex flex-col gap-6">
+              {mockComments.map((comment) => (
+                <div key={comment.commentId} className="flex gap-4">
+                  <div
+                    className="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10 bg-gray-200"
+                    style={{ backgroundImage: `url(${comment.avatar})` }}
+                  />
+                  <div className="flex flex-col flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-bold text-[#111816] dark:text-white">{comment.authorName}</span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">{comment.createdAt}</span>
+                    </div>
+                    <p className="text-gray-700 dark:text-gray-300 mt-1">{comment.content}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/AdoptionEdit.tsx
+++ b/src/pages/AdoptionEdit.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import Header from '../components/layout/Header';
+
+const initial = {
+  title: '우리집 복덩이, 사랑스러운 뭉치를 소개해요!',
+  content: `뭉치가 우리 가족이 된 지 벌써 1년이 지났네요. 처음에는 낯을 많이 가리고 구석에만 숨어있어서 마음이 아팠는데, 이제는 제 무릎에서 잠드는 게 일상이 되었어요. 뭉치가 온 후로 집안에 웃음꽃이 끊이질 않아요. 사지 말고 입양하세요!`,
+  existingImages: [
+    'https://lh3.googleusercontent.com/aida-public/AB6AXuD4ehhEonDO7C8Z1pPPQjxv8xiKRaMHimyLPgxQCRDchvr5uNK21Nl4WrUTIyEESrcXBTosD8sZGHCxRaLPo0FIQ-CTHCtHmMcC2tegYdIzKwRvbxVOpRYg4c2RfNVhD1aTlMpin3VUFWaYk46DJVV9qq6G0jyouPpVcyS7hPDH0SLzZHSlnwsb82HhiefodEcJY5xenQdc28FcY8ggRP2WkwAw35sb3uEFkcMBGzuvfUzfZAPTI-vbK6dudPz2DOxnPV2bVyFDNV0',
+    'https://lh3.googleusercontent.com/aida-public/AB6AXuD2KBVjyXDAZzfA9hkApdTVP-TlUaGCH-IsqlRviMRDBwZ2IWLgnVkTf5YBoT2w9cDhI1RYzAC7aAEirvwOCX0l4YLoIsHmF1MXj8Tj_A3KKISf9VaqrYOmKHQOBgma_pD4LumbTFdm7Ep4doL3P5vXl6n4WWWmcjN5IEFQDZzSRgJvYC8RRuy1BGS0utA_GBDEyNrpOqJcBNIiWMnlF8_poS13Pl0-W-Vo-fnqcYcvwtmMSwaKj_eA5BlqPZUqJsnFSXl7al2CsDQ',
+  ],
+};
+
+export default function AdoptionEdit() {
+  const { id } = useParams<{ id: string }>();
+  const [form, setForm] = useState({
+    title: initial.title,
+    content: initial.content,
+    files: [] as File[],
+  });
+
+  return (
+    <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display text-gray-800 dark:text-gray-200">
+      <div className="layout-container flex h-full grow flex-col">
+        <Header />
+        <div className="flex flex-1 justify-center py-10 sm:py-16 px-4">
+          <div className="layout-content-container flex flex-col max-w-[960px] flex-1">
+            <div className="flex flex-wrap justify-between gap-3 p-4 pb-8">
+              <h1 className="text-[#111816] dark:text-white text-4xl font-black leading-tight tracking-[-0.033em] min-w-72">
+                입양후기 수정
+              </h1>
+            </div>
+
+            <div className="space-y-8 p-4">
+              <label className="flex flex-col w-full">
+                <p className="text-[#111816] dark:text-gray-300 text-base font-bold leading-normal pb-2">제목</p>
+                <input
+                  className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#111816] dark:text-white dark:bg-background-dark focus:outline-0 focus:ring-2 focus:ring-primary/50 border border-[#dbe6e3] dark:border-gray-700 bg-white dark:bg-gray-800 focus:border-primary h-14 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-[15px] text-base font-normal leading-normal"
+                  value={form.title}
+                  onChange={(e) => setForm({ ...form, title: e.target.value })}
+                />
+              </label>
+
+              <label className="flex flex-col w-full">
+                <p className="text-[#111816] dark:text-gray-300 text-base font-bold leading-normal pb-2">내용</p>
+                <textarea
+                  className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#111816] dark:text-white dark:bg-background-dark focus:outline-0 focus:ring-2 focus:ring-primary/50 border border-[#dbe6e3] dark:border-gray-700 bg-white dark:bg-gray-800 focus:border-primary min-h-60 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-[15px] text-base font-normal leading-normal"
+                  value={form.content}
+                  onChange={(e) => setForm({ ...form, content: e.target.value })}
+                />
+              </label>
+
+              <div className="flex flex-col w-full space-y-2">
+                <h2 className="text-[#111816] dark:text-gray-300 text-lg font-bold leading-tight tracking-[-0.015em] text-left">
+                  사진 등록
+                </h2>
+                <div className="flex flex-col items-center gap-6 rounded-lg border-2 border-dashed border-[#dbe6e3] dark:border-gray-700 px-6 py-14">
+                  <div className="flex max-w-[480px] flex-col items-center gap-2">
+                    <p className="text-[#111816] dark:text-white text-lg font-bold leading-tight tracking-[-0.015em] max-w-[480px] text-center">
+                      파일을 드래그 앤 드롭하거나 클릭하여 업로드하세요
+                    </p>
+                    <p className="text-gray-600 dark:text-gray-400 text-sm font-normal leading-normal max-w-[480px] text-center">
+                      💡 새로운 사진을 등록하면 기존 사진은 모두 삭제됩니다.
+                    </p>
+                  </div>
+                  <button className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#f0f5f3] dark:bg-gray-700 text-[#111816] dark:text-white text-sm font-bold leading-normal tracking-[0.015em] hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                    <span className="truncate">파일 선택</span>
+                  </button>
+                </div>
+              </div>
+
+              {/* Existing Images Section */}
+              <div className="w-full">
+                <h3 className="text-base font-bold text-[#111816] dark:text-gray-300 mb-3">현재 등록된 사진</h3>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                  {initial.existingImages.map((url, idx) => (
+                    <div key={idx} className="relative group aspect-square">
+                      <img
+                        className="w-full h-full object-cover rounded-lg"
+                        src={url}
+                        alt={`Existing image ${idx + 1}`}
+                      />
+                      <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 flex items-center justify-center transition-opacity rounded-lg">
+                        <button className="text-white">
+                          <span className="material-symbols-outlined text-4xl">delete</span>
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3 p-4 pt-8">
+              <Link
+                to={`/adoption/${id}`}
+                className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-12 px-6 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 text-base font-bold leading-normal tracking-[0.015em] hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+              >
+                <span className="truncate">취소</span>
+              </Link>
+              <button className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-12 px-6 bg-primary text-background-dark text-base font-bold leading-normal tracking-[0.015em] hover:brightness-90 transition-all">
+                <span className="truncate">수정</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AdoptionList.tsx
+++ b/src/pages/AdoptionList.tsx
@@ -1,0 +1,168 @@
+import { Link } from 'react-router-dom';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+import placeholderImg from '../assets/image-placeholder.svg';
+
+interface AdoptionPostSummary {
+  postId: number;
+  title: string;
+  authorId: number;
+  createdAt: string;
+  imageUrls?: string[];
+}
+
+const mockAdoptionPosts: AdoptionPostSummary[] = [
+  {
+    postId: 1,
+    title: '새로운 가족, 사랑이를 소개합니다!',
+    authorId: 123,
+    createdAt: '2023.10.27',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuClMIlAT1x8W4EOAA4suLM9yM-HzNK1p85c0Som6FLlRVjpwV8bt8CrzeXL9LGfFB8br2gGMG2Psfed1bFbuG08vuC9t0Mv-e5Aprceo5W8bPAu20uuvOMto3RtxM6N46auQIHOKX10StVJwO9stsP4h2DpmBhU-zJj1B6gSq_555LXoGJQgL5Hc4S7u2v9A3ZjqKDzRqhTD3szNjyQjC_Rqn4-rNSvkOHDE0Q804tNHWpdPIYEhdVBZIiJPoW0E41TlA2GZYYMj-s'],
+  },
+  {
+    postId: 2,
+    title: '보호소에서 우리 집 소파까지',
+    authorId: 456,
+    createdAt: '2023.10.26',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuBqgfwUpdwJ0DtOmKSITcjLvJW_aPqZfCJWogDY2K5JYBSydEdVCYd5sTAVLboLfJfeB94tGOTgpALCw4SP3qqkAxRC6bf1LbYVe2yLwA772NXQgRwTCGJW9P4QCTM2l4eFB6ydQ5-jDh5trhFH8PtsRs_xOwsq2lLJIpNohk4u16JAPT_nM7teceVrypnVQwpWijUFeooy44zluMuMQWPfsBmUsd3GTgzt4NH1ZUcDTUDIWANqIQ-qTS5EaY2WnumenEkPWkAZvVs'],
+  },
+  {
+    postId: 3,
+    title: '새로운 고양이와의 멋진 여정',
+    authorId: 789,
+    createdAt: '2023.10.25',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuAwsKhJozk8xrxkBYpqkAWqUHc_enm8J86MTBu4IBZE-y2vDTKdLU2kWLtucy4MDvmfauVNZc41svItMYQG7VdSD-LS2ot3pftTaB_INvj49z2HJcY1viBS9kk4hxKiC9ETSuIHa39ZPFdBnowMiH0qrw9YT9CLjtJnpYvgp8Yd5PghPiRLhJFWuP4DWP1Tjo35hHjyhIiu_NF2rNwzoRThXlua046GmSPzPXackSYn9UKMxCSNS8tR2zUR9PMlTJxCtZfHS-VnHys'],
+  },
+  {
+    postId: 4,
+    title: '오래오래 행복하게',
+    authorId: 321,
+    createdAt: '2023.10.24',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuD24ZLwSg0Ew3-Tzexlx_4U-sazTZC9Uudq7WbHGoqZylZylDz714ppeDw0N78V9XTHbm2yXOyh4dbBu3sXjPyrWBDpqOhBQOAaInYGbDU2b7BNZWqeccKIwcUZbq43mqsQwMAhorTWmU54LTqWriTY7hc0IijVCJdx2rXEosk8nkffJu3hjWOJC6_U1MgTY_oYfvOcTyAWVsby7NUvTnoRkc9kwpea4RdGtH1BwJw3X-0wCdPOEDTnA6z5VZ61uOEZ1kwscJhiv38'],
+  },
+  {
+    postId: 5,
+    title: '우리가 내린 최고의 결정',
+    authorId: 654,
+    createdAt: '2023.10.23',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuC7OUF12Z5VstlrygCN5ug54q4q8BHYiNlJcQiMOBQ10IJ5Anc1vcJDrJgOjyhJGVotloU0Fm03f5TkqFIjjx6KO81LcUnRXNn6DYFQtIfpwTu2FusOQ3-w5_l4GST-2BzRqGJFuE2DeOheDAS-m3cAQXopto3mWSEWAw0ST6BTxMYpJCPZjTqz-ml6JiQyIYTyrHhau5BEaaTltVZfV79MSA_qZ1-DmgXGvbQVrmlm1TiJRWGKuF8xEgEk9GvzTldISUVg0liUcvQ'],
+  },
+  {
+    postId: 6,
+    title: '그는 평생 가족을 찾았어요',
+    authorId: 987,
+    createdAt: '2023.10.22',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuCbiPIF6YgQX54gENnqg-0Od-0whkPIBwnnGA7hfpj5fTWDjoiH6cpyR6YZ8hQkUNdQokimMZ23JIKN3sZXmnRHi_QUP8jeNDnZj9RIJrVRssyeqJCEMXrqJalKdU_RLnwNSz8vArrtxzBJjoEgcIXosT4QcdyaR6osH4e-GuGFRklVo9Dq63rj-7E9Jq3jjAj0ZyJ_aBNo8s-1YKJhsdXTkXNoYTkqOwRHWK8qGlAxAUeE5SMvl7hH8_WmIlNr9dnR2dKE1g4T6yY'],
+  },
+  {
+    postId: 7,
+    title: '세상에서 가장 사랑스러운 강아지',
+    authorId: 147,
+    createdAt: '2023.10.21',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuD7ZybVfcfEj2lt3foxz4GZd_Nm8EE6mBCRHAcSziu-QTrnXZf3WIX66jtpkGkoiG0bih-6duC_uo8jlVaqCUfHHfAIlxXxxT8JwYmqAxBEoiQ8cdO-6j6ILbe6c6gUYqvpiUxFX4hovjV2xxdLIXnhxAkDwhdEu4a8zaRGybx5X78IqrrChSP8PfRpHNWgiY3P6BB6WZxITPoX7-urpySYEGSSFJxpdeD0IdsFvTR0dcBiV4E_ipRUvObTjODKWCsizv3fLxUIqRU'],
+  },
+  {
+    postId: 8,
+    title: '입양 후 두 달',
+    authorId: 258,
+    createdAt: '2023.10.20',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuBlvwEqEx987bIBZy4SO1iI-1TxvAiYJG1CenPa_mnccipsuYcdsWCQiKHpNaMgoJ33b1yqNIijju7L81A1pxw5VeHo8aXrfJt8JsShYslEScZrELbxHjntg14DQ2L-MAdY9Px7VSXOEqrmttaXyZgVpvd3xK-WV-CUL6TABB77gab4QH_pyWBhJO1NIrpmrrF0rtxfRdjch0BQqd-uEURdCJcd3QnzbjRMwu-7yuKtn6nUe9Uk1JV_KwgkNd3HJieUDygrGo4KHU4'],
+  },
+];
+
+export default function AdoptionList() {
+  const resolveImage = (urls?: string[]) => {
+    const first = urls?.[0];
+    if (!first) return placeholderImg;
+    try {
+      const host = new URL(first).hostname;
+      if (host.includes('placeholder.com')) return placeholderImg;
+      return first;
+    } catch {
+      return placeholderImg;
+    }
+  };
+
+  const formatAuthor = (authorId: number) => {
+    return `user_${authorId}`;
+  };
+
+  return (
+    <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display text-[#111816] dark:text-gray-200">
+      <Header />
+      <main className="flex-grow w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-16">
+        {/* PageHeading */}
+        <div className="flex flex-wrap justify-between items-start gap-4 mb-8 sm:mb-12">
+          <div className="flex min-w-72 flex-col gap-2">
+            <p className="text-4xl font-black leading-tight tracking-[-0.033em] text-[#111816] dark:text-white">입양후기</p>
+            <p className="text-base font-normal leading-normal text-[#5f8c80] dark:text-gray-400">커뮤니티의 따뜻한 이야기들을 만나보세요.</p>
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2 text-sm text-[#5f8c80] dark:text-gray-400">
+              <span className="material-symbols-outlined text-lg">lock</span>
+              <span>로그인이 필요한 서비스입니다.</span>
+            </div>
+            <Link
+              to="/adoption/new"
+              className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-primary text-[#111816] text-sm font-bold leading-normal tracking-[0.015em] hover:opacity-90 transition-opacity"
+            >
+              <span className="truncate">작성하기</span>
+            </Link>
+          </div>
+        </div>
+
+        {/* ImageGrid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          {mockAdoptionPosts.map((post) => (
+            <Link
+              key={post.postId}
+              to={`/adoption/${post.postId}`}
+              className="group flex flex-col gap-3 pb-3 cursor-pointer"
+            >
+              <div className="overflow-hidden rounded-lg">
+                <div
+                  className="w-full bg-center bg-no-repeat aspect-video bg-cover transition-transform duration-300 group-hover:scale-105"
+                  style={{
+                    backgroundImage: `url(${resolveImage(post.imageUrls)})`,
+                  }}
+                />
+              </div>
+              <div>
+                <p className="text-base font-medium leading-normal text-[#111816] dark:text-white">{post.title}</p>
+                <p className="text-sm font-normal leading-normal text-[#5f8c80] dark:text-gray-400">
+                  by {formatAuthor(post.authorId)} • {post.createdAt}
+                </p>
+              </div>
+            </Link>
+          ))}
+        </div>
+
+        {/* Pagination */}
+        <div className="flex items-center justify-center p-4 mt-8 sm:mt-12">
+          <button className="flex size-10 items-center justify-center text-[#5f8c80] dark:text-gray-400 hover:text-[#111816] dark:hover:text-white">
+            <span className="material-symbols-outlined text-2xl">chevron_left</span>
+          </button>
+          <button className="text-sm font-bold leading-normal tracking-[0.015em] flex size-10 items-center justify-center text-[#111816] dark:text-white rounded-full bg-primary/30">
+            1
+          </button>
+          <button className="text-sm font-normal leading-normal flex size-10 items-center justify-center text-[#5f8c80] dark:text-gray-400 hover:text-[#111816] dark:hover:text-white rounded-full">
+            2
+          </button>
+          <button className="text-sm font-normal leading-normal flex size-10 items-center justify-center text-[#5f8c80] dark:text-gray-400 hover:text-[#111816] dark:hover:text-white rounded-full">
+            3
+          </button>
+          <button className="text-sm font-normal leading-normal flex size-10 items-center justify-center text-[#5f8c80] dark:text-gray-400 hover:text-[#111816] dark:hover:text-white rounded-full">
+            4
+          </button>
+          <button className="text-sm font-normal leading-normal flex size-10 items-center justify-center text-[#5f8c80] dark:text-gray-400 hover:text-[#111816] dark:hover:text-white rounded-full">
+            5
+          </button>
+          <button className="flex size-10 items-center justify-center text-[#5f8c80] dark:text-gray-400 hover:text-[#111816] dark:hover:text-white">
+            <span className="material-symbols-outlined text-2xl">chevron_right</span>
+          </button>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/CommunityCreate.tsx
+++ b/src/pages/CommunityCreate.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
-import placeholderImg from '../assets/image-placeholder.svg';
 
 type BoardType = 'MISSING' | 'PROTECTION' | 'REPORT' | 'FREE';
 

--- a/src/pages/CommunityCreate.tsx
+++ b/src/pages/CommunityCreate.tsx
@@ -1,0 +1,265 @@
+import { useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+import placeholderImg from '../assets/image-placeholder.svg';
+
+type BoardType = 'MISSING' | 'PROTECTION' | 'REPORT' | 'FREE';
+
+export default function CommunityCreate() {
+  const [searchParams] = useSearchParams();
+  const initialBoardType = (searchParams.get('boardType') as BoardType) || 'MISSING';
+  const isFreeBoard = initialBoardType === 'FREE';
+
+  const [form, setForm] = useState({
+    boardType: initialBoardType,
+    title: '',
+    content: '',
+    files: [] as File[],
+  });
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const newFiles = Array.from(e.target.files);
+      setForm({ ...form, files: [...form.files, ...newFiles] });
+    }
+  };
+
+  const removeFile = (index: number) => {
+    setForm({ ...form, files: form.files.filter((_, i) => i !== index) });
+  };
+
+  // 소통게시판 전용 레이아웃
+  if (isFreeBoard) {
+    return (
+      <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display">
+        <Header />
+        <main className="flex flex-1 items-center justify-center py-10 px-4 sm:px-6 md:px-8">
+          <div className="w-full max-w-4xl bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700">
+            <div className="flex flex-col gap-8 p-6 sm:p-10">
+              <div>
+                <h1 className="text-[#111816] dark:text-white text-4xl font-black leading-tight tracking-[-0.033em]">
+                  소통 게시판 글 작성
+                </h1>
+              </div>
+
+              <div className="flex flex-col gap-6">
+                {/* Title Input */}
+                <label className="flex flex-col w-full">
+                  <p className="text-[#111816] dark:text-white text-base font-medium leading-normal pb-2">
+                    제목 *
+                  </p>
+                  <input
+                    className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#111816] dark:text-white focus:outline-0 focus:ring-2 focus:ring-primary border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 h-14 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-4 text-base font-normal leading-normal"
+                    placeholder="제목을 입력하세요"
+                    value={form.title}
+                    onChange={(e) => setForm({ ...form, title: e.target.value })}
+                  />
+                </label>
+
+                {/* Content Textarea */}
+                <label className="flex flex-col w-full">
+                  <p className="text-[#111816] dark:text-white text-base font-medium leading-normal pb-2">
+                    내용 *
+                  </p>
+                  <textarea
+                    className="form-input flex w-full min-w-0 flex-1 resize-y overflow-hidden rounded-lg text-[#111816] dark:text-white focus:outline-0 focus:ring-2 focus:ring-primary border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 min-h-60 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-4 text-base font-normal leading-normal"
+                    placeholder="자유롭게 이야기를 공유해주세요. (예: 입양 후기, 반려동물 자랑 등)"
+                    value={form.content}
+                    onChange={(e) => setForm({ ...form, content: e.target.value })}
+                  />
+                </label>
+
+                {/* Photo Upload Grid */}
+                <div className="flex flex-col gap-4">
+                  <p className="text-[#111816] dark:text-white text-base font-medium leading-normal">
+                    사진 첨부 (선택)
+                  </p>
+                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                    {form.files.map((file, index) => (
+                      <div key={index} className="relative group aspect-square rounded-lg overflow-hidden">
+                        <img
+                          alt={`Uploaded image ${index + 1}`}
+                          className="w-full h-full object-cover"
+                          src={URL.createObjectURL(file)}
+                        />
+                        <button
+                          className="absolute top-1 right-1 bg-black/50 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                          onClick={() => removeFile(index)}
+                          type="button"
+                        >
+                          <span className="material-symbols-outlined text-base">close</span>
+                        </button>
+                      </div>
+                    ))}
+                    {form.files.length < 10 && (
+                      <label className="flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600 hover:border-primary dark:hover:border-primary transition-colors cursor-pointer aspect-square p-4">
+                        <span className="material-symbols-outlined text-primary text-3xl">add_photo_alternate</span>
+                        <p className="text-gray-500 dark:text-gray-400 text-sm font-medium leading-normal text-center">
+                          사진 추가
+                        </p>
+                        <input
+                          className="sr-only"
+                          multiple
+                          type="file"
+                          accept="image/*"
+                          onChange={handleFileChange}
+                        />
+                      </label>
+                    )}
+                  </div>
+                </div>
+
+                {/* Action Buttons */}
+                <div className="flex flex-col sm:flex-row justify-end items-center gap-4 pt-6 border-t border-gray-200 dark:border-gray-700">
+                  <Link
+                    to="/community"
+                    className="w-full sm:w-auto flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-12 px-6 bg-gray-100 dark:bg-gray-700 text-[#111816] dark:text-white hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors text-base font-bold leading-normal"
+                  >
+                    <span className="truncate">취소</span>
+                  </Link>
+                  <button className="w-full sm:w-auto flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-12 px-6 bg-primary text-white hover:bg-primary/80 transition-colors text-base font-bold leading-normal">
+                    <span className="truncate">등록</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  // 기존 커뮤니티 레이아웃 (실종/보호/제보)
+  return (
+    <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display">
+      <Header />
+      <main className="flex-grow">
+        <div className="container mx-auto px-4 py-8 sm:py-16">
+          <div className="max-w-3xl mx-auto">
+            {/* Page Heading */}
+            <div className="mb-10">
+              <p className="text-gray-800 dark:text-white text-4xl font-black tracking-tight">커뮤니티 글 작성</p>
+            </div>
+
+            {/* Form */}
+            <div className="space-y-8">
+              {/* Board Type Selector */}
+              <div>
+                <label className="block text-base font-medium text-gray-800 dark:text-gray-200 pb-2" htmlFor="boardType">
+                  게시판 선택<span className="text-primary ml-1">*</span>
+                </label>
+                <select
+                  className="form-select w-full rounded-lg text-gray-800 dark:text-gray-200 focus:outline-0 focus:ring-2 focus:ring-primary/50 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:border-primary dark:focus:border-primary h-14 p-[15px] text-base font-normal"
+                  id="boardType"
+                  value={form.boardType}
+                  onChange={(e) => setForm({ ...form, boardType: e.target.value as BoardType })}
+                >
+                  <option disabled value="">
+                    게시판을 선택해주세요
+                  </option>
+                  <option value="MISSING">실종</option>
+                  <option value="PROTECTION">보호</option>
+                  <option value="REPORT">제보</option>
+                </select>
+              </div>
+
+              {/* Title Input */}
+              <div>
+                <label className="block text-base font-medium text-gray-800 dark:text-gray-200 pb-2" htmlFor="title">
+                  제목<span className="text-primary ml-1">*</span>
+                </label>
+                <input
+                  className="form-input w-full rounded-lg text-gray-800 dark:text-gray-200 focus:outline-0 focus:ring-2 focus:ring-primary/50 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:border-primary dark:focus:border-primary h-14 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-[15px] text-base font-normal"
+                  id="title"
+                  placeholder="제목을 입력하세요"
+                  type="text"
+                  value={form.title}
+                  onChange={(e) => setForm({ ...form, title: e.target.value })}
+                />
+              </div>
+
+              {/* Content Textarea */}
+              <div>
+                <label className="block text-base font-medium text-gray-800 dark:text-gray-200 pb-2" htmlFor="content">
+                  내용<span className="text-primary ml-1">*</span>
+                </label>
+                <textarea
+                  className="form-textarea w-full rounded-lg text-gray-800 dark:text-gray-200 focus:outline-0 focus:ring-2 focus:ring-primary/50 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:border-primary dark:focus:border-primary min-h-48 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-[15px] text-base font-normal"
+                  id="content"
+                  placeholder="내용을 입력하세요"
+                  value={form.content}
+                  onChange={(e) => setForm({ ...form, content: e.target.value })}
+                />
+              </div>
+
+              {/* Multi-Image Uploader */}
+              <div>
+                <label className="block text-base font-medium text-gray-800 dark:text-gray-200 pb-2">
+                  사진 첨부 <span className="text-gray-500 dark:text-gray-400 font-normal">(선택)</span>
+                </label>
+                <div className="mt-2 flex justify-center rounded-lg border border-dashed border-gray-400 dark:border-gray-600 px-6 py-10 bg-white/50 dark:bg-gray-800/50">
+                  <div className="text-center">
+                    <span className="material-symbols-outlined text-5xl text-gray-400 dark:text-gray-500">image</span>
+                    <div className="mt-4 flex text-sm leading-6 text-gray-600 dark:text-gray-400">
+                      <label
+                        className="relative cursor-pointer rounded-md font-semibold text-primary focus-within:outline-none focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-2 dark:ring-offset-background-dark hover:text-primary/80"
+                        htmlFor="file-upload"
+                      >
+                        <span>이미지 첨부</span>
+                        <input
+                          className="sr-only"
+                          id="file-upload"
+                          multiple
+                          name="file-upload"
+                          type="file"
+                          onChange={handleFileChange}
+                        />
+                      </label>
+                      <p className="pl-1">또는 드래그 앤 드롭</p>
+                    </div>
+                    <p className="text-xs leading-5 text-gray-500 dark:text-gray-500">PNG, JPG, GIF up to 10MB</p>
+                  </div>
+                </div>
+                {form.files.length > 0 && (
+                  <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                    {form.files.map((file, index) => (
+                      <div key={index} className="relative group">
+                        <div
+                          className="aspect-square w-full rounded-lg bg-cover bg-center"
+                          style={{ backgroundImage: `url(${URL.createObjectURL(file)})` }}
+                        />
+                        <button
+                          className="absolute top-1 right-1 bg-black/50 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                          onClick={() => removeFile(index)}
+                          type="button"
+                        >
+                          <span className="material-symbols-outlined text-base">close</span>
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Action Buttons */}
+              <div className="flex justify-end gap-4 pt-6">
+                <Link
+                  to="/community"
+                  className="flex min-w-[120px] items-center justify-center rounded-lg h-12 px-6 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 text-base font-bold hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+                >
+                  <span>취소</span>
+                </Link>
+                <button className="flex min-w-[120px] items-center justify-center rounded-lg h-12 px-6 bg-primary text-gray-900 text-base font-bold hover:bg-primary/80 transition-colors">
+                  <span>등록하기</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/CommunityDetail.tsx
+++ b/src/pages/CommunityDetail.tsx
@@ -313,7 +313,7 @@ export default function CommunityDetail() {
               />
               {thumbnails.length > 0 && (
                 <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3">
-                  {thumbnails.map((url, idx) => (
+                  {thumbnails.map((url: string, idx: number) => (
                     <div
                       key={idx}
                       className={`w-full bg-center bg-no-repeat bg-cover aspect-square rounded-lg ${

--- a/src/pages/CommunityDetail.tsx
+++ b/src/pages/CommunityDetail.tsx
@@ -1,0 +1,394 @@
+import { Link, useParams } from 'react-router-dom';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+import placeholderImg from '../assets/image-placeholder.svg';
+import { mockPosts } from './CommunityList';
+
+// 상세 페이지용 확장된 데이터 (이미지, 댓글 포함)
+const mockPostDetails: Record<number, any> = {
+  1: {
+    postId: 1,
+    title: 'OO동에서 실종된 강아지를 찾습니다.',
+    content: `2023년 10월 26일 저녁 8시경 OO동 OO공원 근처에서 저희 집 강아지 '몽이'를 잃어버렸습니다.
+
+특징은 다음과 같습니다:
+- 품종: 믹스견 (진돗개 + 리트리버 믹스)
+- 나이: 3살
+- 성별: 수컷 (중성화 완료)
+- 특징: 등쪽에 하얀색 하트 모양의 무늬가 있습니다. 겁이 많아서 사람이 다가가면 도망갈 수 있습니다. 파란색 목줄을 하고 있었습니다.
+
+혹시 몽이를 보셨거나 보호하고 계신 분은 꼭 연락 부탁드립니다. 사례는 꼭 하겠습니다.`,
+    boardType: 'MISSING',
+    authorId: 101,
+    createdAt: '2023.10.27',
+    imageUrls: [
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuCa4HLESnS_vedM0-64iW8jrj6J870TK2Ls3VoUJQgEhL40TsCHF7-c78VrKiG_k_IHz_koRLrkkoPMur-56nEO1JVmq39Nl5QjtugrTHkVrCo-umVIvdvB4lBOlsvQT4PS2dQmPJYxcnvEi9Tq8fkMa-v8Y_u1IU-wznE57Ko9Z_AnPaytJDYKG4ll6ttOKPT_R14QqORxfYWjpP76zZNddeAfTMd6DJj01MTTQDNN2Bm5RCLS9f0Tax45isucgq64mQS4X4jZJzA',
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuA5P0al2KQj7GF-rAGH2UsRztw8I99thG9VebEPn1zJZE80KITDRLsLQE-JviBSDxGipe6B7n4f6uSlAn1HYXSKIWW2FVNIco2kL8q7GJWU_1hnvqadRU8LIZ3VK3evYzD0Pt0fZqMbZEFBTDeqrGdivvcsUTUZgUjcNZ5LJwBhXrIElzRFzjL8EjP0N4vaXkroxAZSOLgchIXHDy0FKG-uMTWwTUxSLP0vvv5QIu7CCCT_s_5nFTjkYLRXIzZIH_IPJr14qZDETrU',
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuAdZ3_HwivJhjGIRn9NfJ8rCG0xS_SAot84FiIgsCDqw3aZ0QZpkUqJCkdt6Ht9GawSzmJLGkgy3Bf3AlhEWAr4H_PFU2M0t8MVYjFfRiot3dEq83mK3RUeloANvYCJlQ02h5cjLb6adwj9eRnNRhMuESYF282doOQqoqc-6G19FkcUDK0AIiBmH08VfcFiE_QQuDBwGtV5vUWlC60aUNz2EZJMdoDFOTAjl9HXU1CcAG7RF0TI6U39Y9znkj4MGcHSI0CG4SRTMdM',
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuA03za-Lxw_vohlM7hUi8vOrGMEqa_akQcF55_qUfPwHXe0a-5brJ7U7qOlTnF8Hh1AlHUDqXYGowIxyQZ1vpvYXD7PHQHEAh-WCKessdMveRJHJsgB1OHyN6aUX9qssjn-ntADp_RQNGdsFTWQz3vJOOo4lvTItKycsFQmOEVpVAo17RH_hFlV5ALo_qad8yyqT8c-KFHjoGgLQRc1kqR252eQ9A4Ze101mPaH9ETtChKoW0bI7Grm4DR_qS5eYshpICw0fz6GaEw',
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuAgKp6QPkENECBqF7ydpLt27hJPAy9E1ZzBprBmIqx0NspZd3CE-h4GjKNLNcWtvf5TpzWQIWeT28COjoRNzRce9awbYgJ7UTKirICGX7DkueE4N1ayJUTf5kbeNQ9mGTq5_K7dIGmEW2zJ8O21j5gzjDcysX9fn1PRE3iziBeH9RxbLK1ffJ9hdtuaWdem5x5dApiOVuj_KPE8MDC7cEcHpcxOag-zAOKWCGf5cZYHi8-3YyATfWwZViwXqeKoKPYQlFsn03Jec4A',
+    ],
+  },
+  // 소통 게시판 글 예시
+  9: {
+    postId: 9,
+    title: '새로운 가족이 된 우리 냥이를 소개합니다!',
+    content: `안녕하세요! 얼마 전 포우 브릿지를 통해 입양한 고양이 '루나'를 소개합니다. 처음 집에 왔을 때는 조금 낯설어했지만, 이제는 완전한 애교쟁이가 되었어요. 매일 아침마다 제 얼굴 옆에서 골골송을 불러주며 깨워준답니다. 
+
+입양을 고민하시는 분들이 계시다면 주저하지 마세요. 아이들에게 따뜻한 가족이 되어주는 것은 정말 행복한 경험입니다. 다른 집사님들과도 많이 소통하고 싶어요!`,
+    boardType: 'FREE',
+    authorId: 201,
+    authorName: '냥냥펀치마스터',
+    createdAt: '2024.08.15',
+    views: 123,
+    imageUrls: [
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuBsdn11oEk0aVreF2_EuJXcgGRQiCc4TQuUZwneR_U7I_3hDBqQKr0zH8f3L_b22ywAxH_Axxwfayd4c-hxgFofvfwfoQXoJXRhEt3KpnlRibgwCoz-rwagaQQlzN4zNHMFKM-6FjBs9zpbg5eernAdzvfnC4joIUhRN3pWYaxzbZUgzoNOk7565gprl0UmeCJ6Q_v9TYVJNU9jOLgXTzdwtEfBGDb6kSxhPFcYXoYUuQUC1ZLdLfgFbCMr3-8Qsh75dJWaudgCCkU',
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuDytvU9xaYy9h76Kg0Av24W8kYb5R8Z3tDJ3vRsw0PyDnLzGAZ7CWwgNlvXmU0gXL7WkmILP-u5yq_6av_iJMICCyqVQ8xIVc80ofN4TqPw78MfYq0ZPHNBXjw2BGU2pa1tVj9EeHZYztNUaQlWBWYNI5lOE7F35bMPnWFuf3mjhCPj2vcNdVnT6lXi8r6T4nykd6QprUtWA7Ri9L4NHpoSbWFtV5wKrPbPRriEiY6erho33coEBl-7g_HFvu9qyy2qmqv1o4uhWco',
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuBLJhwTooQPFoH6qaeH1SzP-zWesJ7ypoGIFWTmKcUk6LBHn7y8rEv3ztNnYJy0KoqN-Bn1izRItLk9BG9L7nFAUzS7MwKlnAafoWEcP5eInyX69-TdtU-Lgrnm_waLbmJ1WfV_C865rAhcK4d3IaTL5bTc9DfxrEu3ZbAfWualehRZzUtrvkDnHwpdsGhoj0TkWFdLxztYDEhdWz3SaKhWUiMjgWSMq8G5dRFRQSS5gwu7PHk43PaNNU0I_lRWzYkyWhno_8AJufQ',
+    ],
+  },
+  10: {
+    postId: 10,
+    title: '고양이랑 친해지는 법 공유해요',
+    content: `길고양이와 친해지고 싶은데 쉽지 않네요. 조금씩 다가가고 있긴 한데, 더 빨리 친해지는 방법이 있을까요?
+
+지금은 매일 같은 시간에 간식을 주고 있는데, 이게 맞는 방법인지 궁금합니다.`,
+    boardType: 'FREE',
+    authorId: 202,
+    createdAt: '2024.10.25',
+    imageUrls: [],
+  },
+};
+
+const mockComments: Record<number, any[]> = {
+  1: [
+    {
+      commentId: 1,
+      authorId: 201,
+      authorName: 'angel1004',
+      content: '꼭 찾으시길 바랍니다! 제가 사는 동네 근처라 유심히 볼게요.',
+      createdAt: '2023.10.27',
+      avatar: 'https://lh3.googleusercontent.com/aida-public/AB6AXuBOMuGcsiFsvpmZYsHA_ldhey55l1lsF08vmeXuKh3E5sdX-as0_M7UORzqpf3N3tRCZQG3JliVOunz0_v4khq-XUb2RUgE4JRKWdLpfaJrARHOQtMIN1A_a6oPdaei5Fhq13RTWMwbvrLMG60FbPYsCotKbCEdQgpRrxmkbBYKhDOo4OZYJWrrEb9B1h1dU4_0RiHwLibgjO2Yj_XbORBGr0G6J6YxHkk7tqsyf0Gg8Km3vzUEibtx-QWm568XPnTsEykGmT-07gk',
+    },
+    {
+      commentId: 2,
+      authorId: 202,
+      authorName: 'doglover',
+      content: '어제 저녁에 OO마트 앞에서 비슷한 강아지를 본 것 같아요! 확실하지는 않지만 확인해보세요.',
+      createdAt: '2023.10.28',
+      avatar: 'https://lh3.googleusercontent.com/aida-public/AB6AXuDf0pke6FF4eBpcIM0O5JJrPZVc35Ta1l1u5_Mqkgr3_IlIx73yZpqKvIRFI6qVpZZdFNIqOF2qdEzyweNsJZ8TIn4wKribT3zbo-Xn7d6IhL84YSC6WF9x4evGazEgvK-4MkpuoKuwSZgh4_7xbwvz_eQFEkheIWT0wr8f2qPo6YquxTjYyszGPWe0Gkse00hvf8RJCII7rjwDLppvkdORMQif3ft-uGnVFmtJASWS5G4gD-_fsDzLdfnQ5fXggsAhaVX9qkAmPmc',
+    },
+  ],
+  9: [
+    {
+      commentId: 1,
+      authorId: 301,
+      authorName: '멍뭉이사랑',
+      content: '루나 너무 예쁘네요! 저희 집 댕댕이랑 친구하면 좋겠어요. 항상 행복하세요!',
+      createdAt: '2024.08.15 14:30',
+      avatar: null,
+    },
+    {
+      commentId: 2,
+      authorId: 302,
+      authorName: '사지말고입양하세요',
+      content: '좋은 가족을 만나서 다행이에요. 글 보고 저도 마음이 따뜻해졌습니다.',
+      createdAt: '2024.08.15 18:55',
+      avatar: null,
+    },
+  ],
+  10: [],
+};
+
+const boardLabel: Record<string, string> = {
+  MISSING: '실종',
+  PROTECTION: '보호',
+  REPORT: '제보',
+  FREE: '소통 게시판',
+};
+
+const resolveImage = (url: string) => {
+  if (!url) return placeholderImg;
+  try {
+    const host = new URL(url).hostname;
+    if (host.includes('placeholder.com')) return placeholderImg;
+    return url;
+  } catch {
+    return placeholderImg;
+  }
+};
+
+export default function CommunityDetail() {
+  const { id } = useParams<{ id: string }>();
+  const postId = id ? parseInt(id, 10) : 1;
+
+  // mockPostDetails에 있으면 사용, 없으면 mockPosts에서 찾기
+  let mockPost = mockPostDetails[postId];
+  if (!mockPost) {
+    const listPost = mockPosts.find((p) => p.postId === postId);
+    if (listPost) {
+      mockPost = {
+        ...listPost,
+        content: `${listPost.title}에 대한 상세 내용입니다.`,
+        imageUrls: listPost.imageUrls || [],
+      };
+    } else {
+      // 기본값
+      mockPost = mockPostDetails[1];
+    }
+  }
+
+  const isFreeBoard = mockPost.boardType === 'FREE';
+  const mainImage = mockPost.imageUrls?.[0] || placeholderImg;
+  const thumbnails = mockPost.imageUrls?.slice(1) || [];
+  const comments = mockComments[postId] || [];
+
+  // 소통게시판 전용 레이아웃
+  if (isFreeBoard) {
+    return (
+      <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display">
+        <Header />
+        <main className="flex flex-1 justify-center py-5 sm:py-10 px-4">
+          <div className="flex flex-col max-w-4xl flex-1 gap-8">
+            <div className="px-4">
+              <h1 className="text-[#111816] dark:text-white text-3xl md:text-4xl font-black leading-tight tracking-[-0.033em]">
+                소통 게시판
+              </h1>
+            </div>
+
+            {/* Post Card */}
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm overflow-hidden">
+              <div className="flex flex-col gap-6 p-6 md:p-8">
+                <div className="flex flex-col gap-3 pb-6">
+                  <span className="inline-block px-2.5 py-1 bg-primary/20 dark:bg-primary/30 text-primary text-xs font-semibold rounded-full self-start">
+                    소통 게시판
+                  </span>
+                  <h2 className="text-[#111816] dark:text-white tracking-tight text-2xl md:text-3xl font-bold leading-tight">
+                    {mockPost.title}
+                  </h2>
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-gray-500 dark:text-gray-400 text-sm font-normal leading-normal">
+                    <span className="font-medium text-[#111816] dark:text-white">
+                      {mockPost.authorName || `user${mockPost.authorId}`}
+                    </span>
+                    <span>{mockPost.createdAt}</span>
+                    {mockPost.views && <span>조회수 {mockPost.views}</span>}
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-8 py-2 border-t border-gray-200 dark:border-gray-700 pt-8">
+                  <p className="text-[#111816] dark:text-gray-300 leading-relaxed text-base whitespace-pre-line">
+                    {mockPost.content}
+                  </p>
+
+                  {/* Image Grid - 소통게시판은 그리드 형태 */}
+                  {mockPost.imageUrls && mockPost.imageUrls.length > 0 && (
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                      {mockPost.imageUrls.map((url: string, idx: number) => (
+                        <div key={idx} className="aspect-square bg-gray-100 dark:bg-gray-700 rounded-lg overflow-hidden">
+                          {url ? (
+                            <img
+                              alt={`Image ${idx + 1}`}
+                              className="w-full h-full object-cover"
+                              src={resolveImage(url)}
+                              onError={(e) => {
+                                (e.target as HTMLImageElement).src = placeholderImg;
+                              }}
+                            />
+                          ) : (
+                            <div className="w-full h-full flex items-center justify-center text-center text-gray-400 dark:text-gray-500">
+                              <div>
+                                <span className="material-symbols-outlined text-4xl">image_not_supported</span>
+                                <p className="text-xs mt-1">이미지 로드 실패</p>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Action Buttons */}
+                <div className="flex justify-end gap-3 pt-6 border-t border-gray-200 dark:border-gray-700">
+                  <Link
+                    to={`/community/${postId}/edit`}
+                    className="flex min-w-[84px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-primary/20 dark:bg-primary/30 text-primary text-sm font-bold leading-normal tracking-[0.015em] hover:bg-primary/30 dark:hover:bg-primary/40 transition-colors"
+                  >
+                    <span className="truncate">수정</span>
+                  </Link>
+                  <button className="flex min-w-[84px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-transparent text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#111816] dark:hover:text-white transition-colors">
+                    <span className="truncate">삭제</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Comments Card - 별도 카드로 분리 */}
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm">
+              <div className="flex flex-col gap-6 p-6 md:p-8">
+                <h3 className="text-[#111816] dark:text-white text-lg font-bold">댓글 {comments.length}개</h3>
+
+                {/* Comment Input Form */}
+                <div className="flex flex-col gap-3">
+                  <textarea
+                    className="w-full bg-gray-50 dark:bg-gray-900 text-[#111816] dark:text-gray-200 placeholder:text-gray-400 dark:placeholder:text-gray-500 border border-gray-200 dark:border-gray-700 rounded-lg p-3 focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+                    placeholder="따뜻한 댓글을 남겨주세요..."
+                    rows={3}
+                  />
+                  <div className="flex justify-end">
+                    <button className="flex min-w-[96px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-primary text-[#111816] text-sm font-bold leading-normal tracking-[0.015em] hover:bg-opacity-80 transition-colors">
+                      <span className="truncate">등록</span>
+                    </button>
+                  </div>
+                </div>
+
+                {/* Comments List */}
+                <div className="flex flex-col gap-6 pt-4">
+                  {comments.map((comment) => (
+                    <div key={comment.commentId} className="flex gap-4">
+                      <div className="flex-shrink-0">
+                        {comment.avatar ? (
+                          <div
+                            className="w-10 h-10 rounded-full bg-center bg-no-repeat bg-cover"
+                            style={{ backgroundImage: `url(${comment.avatar})` }}
+                          />
+                        ) : (
+                          <div className="w-10 h-10 rounded-full bg-primary/20 dark:bg-primary/30 flex items-center justify-center">
+                            <span className="material-symbols-outlined text-primary text-xl">
+                              {comment.commentId % 2 === 0 ? 'pets' : 'person'}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-1.5">
+                          <span className="font-bold text-[#111816] dark:text-white text-sm">{comment.authorName}</span>
+                          <span className="text-gray-500 dark:text-gray-400 text-xs">{comment.createdAt}</span>
+                        </div>
+                        <p className="text-[#111816] dark:text-gray-300 text-sm leading-relaxed">{comment.content}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  // 기존 커뮤니티 레이아웃 (실종/보호/제보)
+  return (
+    <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display text-[#111816] dark:text-gray-200">
+      <Header />
+      <main className="flex w-full flex-1 justify-center py-8 px-4 sm:px-6 lg:px-8">
+        <div className="flex w-full max-w-4xl flex-col gap-8">
+          {/* Post Header */}
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-8 shrink-0 items-center justify-center gap-x-2 rounded-lg bg-primary/30 px-4">
+                <p className="text-[#111816] dark:text-gray-800 text-sm font-bold leading-normal">
+                  {boardLabel[mockPost.boardType] || '커뮤니티'}
+                </p>
+              </div>
+            </div>
+            <div>
+              <p className="text-[#111816] dark:text-gray-100 text-3xl md:text-4xl font-black leading-tight tracking-[-0.033em]">
+                {mockPost.title}
+              </p>
+              <p className="text-gray-500 dark:text-gray-400 text-base font-normal leading-normal mt-3">
+                user{mockPost.authorId} · {mockPost.createdAt}
+              </p>
+            </div>
+          </div>
+
+          {/* Image Gallery - 이미지가 있을 때만 표시 */}
+          {mockPost.imageUrls && mockPost.imageUrls.length > 0 && (
+            <div className="flex flex-col gap-4">
+              <div
+                className="w-full bg-center bg-no-repeat bg-cover flex flex-col justify-end overflow-hidden bg-gray-200 dark:bg-gray-800 rounded-xl aspect-video"
+                style={{ backgroundImage: `url(${resolveImage(mainImage)})` }}
+              />
+              {thumbnails.length > 0 && (
+                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3">
+                  {thumbnails.map((url, idx) => (
+                    <div
+                      key={idx}
+                      className={`w-full bg-center bg-no-repeat bg-cover aspect-square rounded-lg ${
+                        idx === 0 ? 'border-2 border-primary' : 'cursor-pointer opacity-70 hover:opacity-100 transition-opacity'
+                      }`}
+                      style={{ backgroundImage: `url(${resolveImage(url)})` }}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Post Body */}
+          <div className="flex flex-col gap-4">
+            <p className="text-[#111816] dark:text-gray-300 text-base font-normal leading-relaxed whitespace-pre-line">
+              {mockPost.content}
+            </p>
+          </div>
+
+          {/* Action Buttons (for author) */}
+          <div className="flex justify-end gap-2">
+            <Link
+              to={`/community/${postId}/edit`}
+              className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-primary/20 dark:bg-primary/30 text-[#111816] dark:text-gray-100 text-sm font-bold leading-normal tracking-[0.015em] hover:bg-primary/30 dark:hover:bg-primary/40 transition-colors"
+            >
+              <span className="truncate">수정</span>
+            </Link>
+            <button className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-red-500/20 text-red-700 dark:text-red-300 dark:bg-red-500/30 text-sm font-bold leading-normal tracking-[0.015em] hover:bg-red-500/30 dark:hover:bg-red-500/40 transition-colors">
+              <span className="truncate">삭제</span>
+            </button>
+          </div>
+
+          <hr className="border-gray-200 dark:border-gray-700 my-4" />
+
+          {/* Comments Section */}
+          <div className="flex flex-col gap-6">
+            <h3 className="text-xl font-bold text-[#111816] dark:text-gray-100">댓글 {comments.length}개</h3>
+
+            {/* Comment Input Form (Logged In) */}
+            <div className="flex flex-col gap-2">
+              <textarea
+                className="w-full rounded-lg border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 p-4 text-[#111816] dark:text-gray-200 focus:border-primary focus:ring-primary focus:ring-opacity-50"
+                placeholder="따뜻한 댓글을 남겨주세요."
+                rows={3}
+              />
+              <div className="flex justify-end">
+                <button className="flex min-w-[100px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-primary text-[#111816] text-sm font-bold leading-normal tracking-[0.015em] hover:brightness-90 transition-all">
+                  <span className="truncate">댓글 등록</span>
+                </button>
+              </div>
+            </div>
+
+            {/* Comments List */}
+            <div className="flex flex-col gap-6">
+              {comments.map((comment) => (
+                <div key={comment.commentId} className="flex gap-4">
+                  <div
+                    className="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10 flex-shrink-0 bg-gray-200"
+                    style={{ backgroundImage: comment.avatar ? `url(${comment.avatar})` : undefined }}
+                  />
+                  <div className="flex flex-col w-full">
+                    <div className="flex items-center gap-2">
+                      <span className="font-bold text-[#111816] dark:text-gray-100">{comment.authorName}</span>
+                      <span className="text-sm text-gray-500 dark:text-gray-400">{comment.createdAt}</span>
+                    </div>
+                    <p className="text-[#111816] dark:text-gray-300 mt-1">{comment.content}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/CommunityEdit.tsx
+++ b/src/pages/CommunityEdit.tsx
@@ -1,0 +1,364 @@
+import { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+import { mockPosts } from './CommunityList';
+
+// boardType별 초기 데이터
+const initialDataByType: Record<string, any> = {
+  MISSING: {
+    title: '저희 강아지를 찾습니다 (서울숲 근처)',
+    content: `어제 저녁 8시경 서울숲 근처에서 산책하다가 놓쳤습니다. 이름은 '해피'이고, 5살 된 말티즈입니다. 흰색 털에 파란색 목줄을 하고 있었습니다. 사람을 잘 따르는 편입니다. 보신 분은 꼭 연락 부탁드립니다.`,
+    boardType: 'MISSING',
+    boardLabel: '실종 신고',
+    existingFiles: ['강아지_사진1.jpg', '강아지_사진2.png'],
+  },
+  PROTECTION: {
+    title: '보호 중인 고양이 주인 찾습니다',
+    content: `OO동에서 발견한 고양이를 임시 보호하고 있습니다. 건강 상태는 양호하며, 사람을 잘 따릅니다. 주인을 찾고 있습니다.`,
+    boardType: 'PROTECTION',
+    boardLabel: '보호',
+    existingFiles: ['고양이_사진1.jpg'],
+  },
+  REPORT: {
+    title: '유기견으로 보이는 강아지 발견',
+    content: `OO공원 근처에서 유기견으로 보이는 강아지를 발견했습니다. 도움을 주실 수 있는 분 연락 부탁드립니다.`,
+    boardType: 'REPORT',
+    boardLabel: '제보',
+    existingFiles: ['제보_사진1.jpg'],
+  },
+  FREE: {
+    title: '저희 집 귀염둥이 강아지를 소개합니다!',
+    content: `안녕하세요! Paw Bridge 커뮤니티에 처음으로 글을 남깁니다. 저희 집 사랑스러운 강아지 '코코'를 소개하고 싶어서요. 코코는 2살 된 믹스견인데, 에너지가 넘치고 사람을 정말 좋아해요. 최근에 공원에서 다른 강아지 친구들과 신나게 뛰어노는 사진 몇 장 올려봅니다. 다들 즐거운 하루 보내세요!`,
+    boardType: 'FREE',
+    boardLabel: '소통 게시판',
+    existingFiles: ['coco_park_photo_01.jpg', 'coco_park_photo_02.jpg'],
+  },
+};
+
+export default function CommunityEdit() {
+  const { id } = useParams<{ id: string }>();
+  const postId = id ? parseInt(id, 10) : 1;
+
+  // mockPosts에서 해당 글 찾기
+  const listPost = mockPosts.find((p) => p.postId === postId);
+  const boardType = listPost?.boardType || 'MISSING';
+  const initialData = initialDataByType[boardType] || initialDataByType.MISSING;
+  const isFreeBoard = boardType === 'FREE';
+
+  const [form, setForm] = useState({
+    title: initialData.title,
+    content: initialData.content,
+    boardType: initialData.boardType,
+    files: [] as File[],
+  });
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const newFiles = Array.from(e.target.files);
+      setForm({ ...form, files: [...form.files, ...newFiles] });
+    }
+  };
+
+  const removeExistingFile = (index: number) => {
+    // 기존 파일 삭제 로직 (실제로는 API 호출 필요)
+    console.log('Remove existing file:', index);
+  };
+
+  const removeNewFile = (index: number) => {
+    setForm({ ...form, files: form.files.filter((_, i) => i !== index) });
+  };
+
+  // 소통게시판 전용 레이아웃
+  if (isFreeBoard) {
+    return (
+      <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display">
+        <Header />
+        <main className="flex flex-1 w-full items-center justify-center p-4 py-10 sm:p-8 md:p-10">
+          <div className="w-full max-w-4xl bg-white dark:bg-gray-800 p-6 sm:p-8 md:p-10 rounded-xl shadow-lg">
+            <div className="flex flex-col">
+              {/* Breadcrumb */}
+              <div className="flex flex-wrap gap-2 items-center text-sm mb-6">
+                <Link to="/" className="text-gray-500 dark:text-gray-400 hover:text-primary dark:hover:text-primary">
+                  홈
+                </Link>
+                <span className="text-gray-400 dark:text-gray-500">/</span>
+                <Link
+                  to="/community"
+                  className="text-gray-500 dark:text-gray-400 hover:text-primary dark:hover:text-primary"
+                >
+                  소통 게시판
+                </Link>
+                <span className="text-gray-400 dark:text-gray-500">/</span>
+                <span className="text-[#111816] dark:text-white font-medium">글 수정</span>
+              </div>
+
+              <h1 className="text-3xl sm:text-4xl font-black text-[#111816] dark:text-white tracking-[-0.033em] mb-8">
+                게시글 수정
+              </h1>
+
+              <form className="flex flex-col gap-6">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  {/* Board Type - Disabled */}
+                  <div>
+                    <label
+                      className="text-[#111816] dark:text-white text-base font-medium leading-normal pb-2 block"
+                      htmlFor="boardType"
+                    >
+                      게시판
+                    </label>
+                    <div className="relative flex w-full items-stretch">
+                      <input
+                        className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 focus:outline-0 focus:ring-2 focus:ring-primary border-transparent h-12 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-3 text-base font-normal leading-normal disabled:cursor-not-allowed"
+                        disabled
+                        id="boardType"
+                        value={initialData.boardLabel}
+                      />
+                      <div className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 dark:text-gray-500">
+                        <span className="material-symbols-outlined">lock</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Title */}
+                  <div>
+                    <label
+                      className="text-[#111816] dark:text-white text-base font-medium leading-normal pb-2 block"
+                      htmlFor="postTitle"
+                    >
+                      제목<span className="text-red-500 ml-1">*</span>
+                    </label>
+                    <input
+                      className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#111816] dark:text-white bg-white dark:bg-gray-900 focus:outline-0 focus:ring-2 focus:ring-primary border border-gray-300 dark:border-gray-600 focus:border-primary dark:focus:border-primary h-12 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-3 text-base font-normal leading-normal"
+                      id="postTitle"
+                      value={form.title}
+                      onChange={(e) => setForm({ ...form, title: e.target.value })}
+                    />
+                  </div>
+                </div>
+
+                {/* Content */}
+                <div>
+                  <label
+                    className="text-[#111816] dark:text-white text-base font-medium leading-normal pb-2 block"
+                    htmlFor="postContent"
+                  >
+                    내용<span className="text-red-500 ml-1">*</span>
+                  </label>
+                  <textarea
+                    className="form-textarea flex w-full min-w-0 flex-1 resize-y overflow-hidden rounded-lg text-[#111816] dark:text-white bg-white dark:bg-gray-900 focus:outline-0 focus:ring-2 focus:ring-primary border border-gray-300 dark:border-gray-600 focus:border-primary dark:focus:border-primary h-60 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-3 text-base font-normal leading-normal"
+                    id="postContent"
+                    value={form.content}
+                    onChange={(e) => setForm({ ...form, content: e.target.value })}
+                  />
+                </div>
+
+                {/* File Attachments */}
+                <div>
+                  <p className="text-[#111816] dark:text-white text-base font-medium leading-normal pb-2 block">
+                    첨부 파일
+                  </p>
+                  <div className="flex flex-col gap-4 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 p-4">
+                    {/* Existing Files */}
+                    {initialData.existingFiles && initialData.existingFiles.length > 0 && (
+                      <>
+                        {initialData.existingFiles.map((filename: string, idx: number) => (
+                          <div
+                            key={idx}
+                            className="flex justify-between items-center bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700"
+                          >
+                            <div className="flex items-center gap-3">
+                              <span className="material-symbols-outlined text-primary">description</span>
+                              <span className="text-[#111816] dark:text-white text-sm">{filename}</span>
+                            </div>
+                            <button
+                              className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
+                              onClick={() => removeExistingFile(idx)}
+                              type="button"
+                            >
+                              <span className="material-symbols-outlined text-xl">close</span>
+                            </button>
+                          </div>
+                        ))}
+                      </>
+                    )}
+
+                    {/* New Files Upload */}
+                    <div className="relative mt-2 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-6 flex flex-col items-center justify-center text-center hover:border-primary dark:hover:border-primary transition-colors bg-white dark:bg-gray-800">
+                      <span className="material-symbols-outlined text-4xl text-primary mb-2">upload_file</span>
+                      <p className="text-gray-600 dark:text-gray-400">파일을 드래그 앤 드롭하거나 클릭하여 업로드하세요</p>
+                      <p className="text-gray-400 dark:text-gray-500 text-sm mt-1">PNG, JPG, GIF (최대 10MB)</p>
+                      <input
+                        className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                        multiple
+                        type="file"
+                        accept="image/*"
+                        onChange={handleFileChange}
+                      />
+                    </div>
+
+                    {/* Info Message */}
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 flex items-center">
+                      <span className="material-symbols-outlined text-base align-middle mr-1">info</span>
+                      새로운 파일을 업로드하면 기존 파일은 모두 삭제되고 새로 첨부됩니다.
+                    </p>
+
+                    {/* New Files Preview */}
+                    {form.files.length > 0 && (
+                      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mt-4">
+                        {form.files.map((file, index) => (
+                          <div key={index} className="relative group aspect-square rounded-lg overflow-hidden">
+                            <img
+                              alt={`New file ${index + 1}`}
+                              className="w-full h-full object-cover"
+                              src={URL.createObjectURL(file)}
+                            />
+                            <button
+                              className="absolute top-1 right-1 bg-black/50 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                              onClick={() => removeNewFile(index)}
+                              type="button"
+                            >
+                              <span className="material-symbols-outlined text-base">close</span>
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Action Buttons */}
+                <div className="flex justify-end gap-4 mt-6">
+                  <Link
+                    to={`/community/${id}`}
+                    className="flex min-w-[120px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-12 px-6 bg-gray-200 dark:bg-gray-700 text-[#111816] dark:text-white text-base font-bold leading-normal tracking-[0.015em] hover:bg-gray-300 dark:hover:bg-gray-600"
+                  >
+                    <span className="truncate">취소</span>
+                  </Link>
+                  <button
+                    className="flex min-w-[120px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-12 px-6 bg-primary text-[#111816] text-base font-bold leading-normal tracking-[0.015em] hover:bg-opacity-90"
+                    type="submit"
+                  >
+                    <span className="truncate">수정</span>
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  // 기존 커뮤니티 레이아웃 (실종/보호/제보)
+  return (
+    <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display text-gray-800 dark:text-gray-200">
+      <Header />
+      <main className="flex-grow">
+        <div className="container mx-auto px-4 py-10">
+          <div className="mx-auto max-w-4xl">
+            <div className="mb-8">
+              <h1 className="text-gray-900 dark:text-white text-4xl font-black leading-tight tracking-[-0.033em]">
+                커뮤니티 글 수정
+              </h1>
+            </div>
+
+            <div className="bg-white dark:bg-background-dark/80 rounded-xl shadow-sm p-6 md:p-8">
+              <form className="space-y-6">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                  <div className="md:col-span-1">
+                    <label className="flex flex-col">
+                      <p className="text-base font-medium leading-normal pb-2 text-gray-900 dark:text-white">게시판</p>
+                      <input
+                        className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-gray-500 dark:text-gray-400 focus:outline-0 focus:ring-0 border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 h-14 p-[15px] text-base font-normal leading-normal cursor-not-allowed"
+                        disabled
+                        readOnly
+                        value={initialData.boardLabel}
+                      />
+                    </label>
+                  </div>
+                  <div className="md:col-span-2">
+                    <label className="flex flex-col">
+                      <p className="text-base font-medium leading-normal pb-2 text-gray-900 dark:text-white">
+                        제목 *
+                      </p>
+                      <input
+                        className="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-gray-900 dark:text-white focus:outline-0 focus:ring-2 focus:ring-primary/50 border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/50 h-14 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-[15px] text-base font-normal leading-normal"
+                        value={form.title}
+                        onChange={(e) => setForm({ ...form, title: e.target.value })}
+                      />
+                    </label>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="flex flex-col">
+                    <p className="text-base font-medium leading-normal pb-2 text-gray-900 dark:text-white">내용 *</p>
+                    <textarea
+                      className="form-input flex w-full min-w-0 flex-1 resize-y overflow-hidden rounded-lg text-gray-900 dark:text-white focus:outline-0 focus:ring-2 focus:ring-primary/50 border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/50 min-h-60 placeholder:text-gray-400 dark:placeholder:text-gray-500 p-[15px] text-base font-normal leading-normal"
+                      value={form.content}
+                      onChange={(e) => setForm({ ...form, content: e.target.value })}
+                    />
+                  </label>
+                </div>
+
+                <div>
+                  <p className="text-base font-medium leading-normal pb-2 text-gray-900 dark:text-white">첨부 파일</p>
+                  <div className="space-y-4">
+                    <div className="flex items-center gap-3 bg-primary/20 text-gray-800 dark:text-gray-200 rounded-lg px-4 py-3 text-sm">
+                      <span className="material-symbols-outlined text-primary">lightbulb</span>
+                      <p>새로운 파일을 업로드하면 기존 첨부 파일은 모두 삭제됩니다.</p>
+                    </div>
+                    <div className="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-6 text-center cursor-pointer hover:border-primary dark:hover:border-primary hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+                      <div className="flex flex-col items-center justify-center space-y-2">
+                        <span className="material-symbols-outlined text-4xl text-gray-400 dark:text-gray-500">
+                          upload_file
+                        </span>
+                        <p className="text-gray-600 dark:text-gray-400">파일을 드래그 앤 드롭하거나 클릭하여 업로드하세요</p>
+                        <p className="text-xs text-gray-500 dark:text-gray-500">PNG, JPG, GIF (최대 5MB)</p>
+                      </div>
+                      <input className="sr-only" multiple type="file" />
+                    </div>
+                    {initialData.existingFiles && initialData.existingFiles.length > 0 && (
+                      <div className="space-y-2">
+                        <p className="text-sm font-medium text-gray-700 dark:text-gray-300">현재 첨부된 파일:</p>
+                        {initialData.existingFiles.map((filename: string, idx: number) => (
+                          <div key={idx} className="flex items-center justify-between p-3 bg-gray-100 dark:bg-gray-800 rounded-lg">
+                            <div className="flex items-center gap-3">
+                              <span className="material-symbols-outlined text-gray-500">description</span>
+                              <span className="text-sm text-gray-800 dark:text-gray-200">{filename}</span>
+                            </div>
+                            <button className="text-gray-500 hover:text-red-500" type="button">
+                              <span className="material-symbols-outlined text-xl">delete</span>
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex flex-col sm:flex-row justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+                  <Link
+                    to={`/community/${id}`}
+                    className="flex w-full sm:w-auto items-center justify-center rounded-lg h-12 px-6 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-white text-base font-bold leading-normal tracking-[0.015em] hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    <span className="truncate">취소</span>
+                  </Link>
+                  <button
+                    className="flex w-full sm:w-auto items-center justify-center rounded-lg h-12 px-6 bg-primary text-gray-900 text-base font-bold leading-normal tracking-[0.015em] hover:brightness-90 transition-all"
+                    type="submit"
+                  >
+                    <span className="truncate">수정</span>
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/CommunityList.tsx
+++ b/src/pages/CommunityList.tsx
@@ -1,0 +1,358 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Header from '../components/layout/Header';
+import placeholderImg from '../assets/image-placeholder.svg';
+
+type BoardType = 'MISSING' | 'PROTECTION' | 'REPORT' | 'FREE';
+
+interface CommunityPostSummary {
+  postId: number;
+  title: string;
+  boardType: BoardType;
+  authorId: number;
+  createdAt: string;
+  imageUrls?: string[];
+  views?: number;
+}
+
+export const mockPosts: CommunityPostSummary[] = [
+  {
+    postId: 1,
+    title: 'OO동에서 실종된 강아지를 찾습니다.',
+    boardType: 'MISSING',
+    authorId: 101,
+    createdAt: '2024-10-26',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuD7Pg_GffqU4AE_Ze3agQyd1yhST4WQTOOmLTkAnBP1VSdNXgsUF51wEbVRCfu8L-m1L-RRt75NmnXYS3kttvoO14JHiGT4qXPjKEngJ7e8QRwUKh2z0GbhleqheavIkiEVWe8bL1wI97vBEpUK8065rXBIQtDeosjZbYXj8t9QmHAiL0CjbD6OP7dKhqB01Y-XJVHk4oYQ0JDhWeGmwq3ssfTbwHPJzP5l0-aP86LfWL-eL_IvzsF37QS-yAvnRAGM5LjQ_RnJir4'],
+  },
+  {
+    postId: 2,
+    title: '보호중인 고양이를 찾습니다.',
+    boardType: 'PROTECTION',
+    authorId: 102,
+    createdAt: '2024-10-26',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuDlJt2QC96OImZuGGTI88NtejEZgWWNasB3AHM3PLGpGXPH23FOTSx0tSivUqmZPHChJ3zYLc_B9t2r7ND4wedxJmKGTM_fpjKUqpoXG5ygaT6EE051Xsga9epHJujI9GH7xHuW5-0QUBRBNIlUWnH8fGaSIC09NHmykj1TA2bwT2XFnc43dX38M-FMNHaM7Be0vYTRy31F2jaDc9gfTUzOIEdYxlo5PsYDSkXnHUL3RpdxqG5wLyn1pJtX2899TJXCQBfhhwy88D0'],
+  },
+  {
+    postId: 3,
+    title: '강아지를 찾습니다.',
+    boardType: 'MISSING',
+    authorId: 103,
+    createdAt: '2024-10-25',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuAl-wzy55nASVdAoFA35PrgwSpNVb_c7CjEkeIMOIqgYvx6nQWEkmvFwjf26WdtS-Klq4xfyGTXu_6xaEsPfbdG3JOyrRaOvxqKWAY9TDTkcJlwhEEOPrRtQXXzu15Z1ItktS6zQSrEY-mkxlOnnmL2wXVUlM4mMsSrhMHQbmQ1hwTyFG9Klo1gm7d4-Wqjpu0xwmFIBkNFqe4aWYSSSLdM7FBvzTPcE1gXdk5G_YHHuJUSFtxn4gOst6pnh3tVmE3r70hOiAR1zNQ'],
+  },
+  {
+    postId: 4,
+    title: '고양이를 찾습니다.',
+    boardType: 'MISSING',
+    authorId: 104,
+    createdAt: '2024-10-25',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuCtSU28pG6PlzxwTplfEoBpUme_p6FbAln7lo46-pk8DcC-XVPrRSOBSeNYy8IuvdGQJbXhG340CoacxYL34QBOSQoQFamEPdguJHuW7_sdoJU2bTOTw0eA5spwlNeX36tBkKuWauGtmdI1S1F_IGNLCOgzO_0Bm1D9gAwxk0Om87dNXIHecV2PkKipLfUjEgMb5HsmSq8rHLEe_1PM7FweUt_qMEdl06cu9hH1EkQ0T1rxVb_-4rdRfColFn-9cQbllxPJ4HWO7qw'],
+  },
+  {
+    postId: 5,
+    title: '보호중인 고양이 주인을 찾습니다.',
+    boardType: 'PROTECTION',
+    authorId: 105,
+    createdAt: '2024-10-24',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuA7I3I3Vth7U5CcYQzJ8n1JD3uJsq1bZ6Kq0190jKizzG6yZdswpf1k0Q-o20R9k07kT1ukkHCOyfXZLP_1iOlCFOhzkpDtE0rd498EiURjDPb8OahlfsEG_DP6hpDk6gBvwT1s3p3GgvJiCo8RnlKsXWWAIPZ2X3wf2YybuVnb_5aH60qINPUrXBzxHHO4SCGJjZ-vLapPl38yN0eeX60u3h9N3DSsd8WT3QIdtDhTM4Ekz46MxG5A4jLTT3tZp_ZYD3xfgRTv75M'],
+  },
+  {
+    postId: 6,
+    title: '강아지 주인을 찾습니다.',
+    boardType: 'PROTECTION',
+    authorId: 106,
+    createdAt: '2024-10-24',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuBUuA-hOGID5mxh4iYCVyrdAu3f2aoxdFGNspyO-ogSpJBAnmAk-hPu4O-Q9LQeko5fkU_H-Fn7uc_wB9LkCxamg7ofvr9oBi8tctjjLi0O6tSSeywKKNcSTDA1tHXhN3Hpv5VNVxeQ-Q9hMp7YZC7Ysp73pGXEzecb5WclGFMcvQmbQN7tXk9lkUShgUGt205gnXTBYVPwPcdAbRq6faAfQj1NjH1RfOv_7sZDHcrapS-2ls0wR1XzJQsiUQoU1DYdgcqkn9vIx5c'],
+  },
+  {
+    postId: 7,
+    title: '주인을 찾습니다.',
+    boardType: 'PROTECTION',
+    authorId: 107,
+    createdAt: '2024-10-23',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuCGMjNyZ4-bbegnCcYOh2kMzUcCyLj_A3BBfDY7ioE6PQt7WATsBOfvdlOHDQtF_FkM5AlR-hlZZmN1AXzVfeAOKIeB6PUnQm-PBkXmWxQnKLEj6yjINNslpJ_c_NF5Q5DnekTMXAeZzCMhAYYECWbN4_yF-9_ACkHONg_VRptDuo_YzHE9QZ6W9M3Q3n2Jq_zFRB01lzJ4rbTwOpg9-YSOORVt29V0-z3fIzyE24CZylI9yzOlRqHmsrKcWJ2lDCy6IWa84jaDy1I'],
+  },
+  {
+    postId: 8,
+    title: 'OO동에서 실종된 고양이를 찾습니다.',
+    boardType: 'MISSING',
+    authorId: 108,
+    createdAt: '2024-10-23',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuC_71watIg2LiSLHQsm-t5nVdSLtIwMyPf-z5ro_MRYDblJzzgs12pw_4JgH-OHz99KHNGPjDA4iM1kYwkzkl0gdvWOdBUNDgcodEGMs8zatd4YSq3YQZc6Pz2hV7WU8dNFe9nvs_i7CgTO3Et_WbZlOf0jdwfikocEv--7FFdODC19LTM8HTAxC6vsdrm8A9qsK-774JmeeCkdtUMtyXG0zOMeFaXm29sFAByPEn0aeGOr2uAJdPRNtwc09l75T-6bSKYsr24A5IA'],
+  },
+  // 제보 게시판 목데이터
+  {
+    postId: 17,
+    title: '유기견으로 보이는 강아지 발견',
+    boardType: 'REPORT',
+    authorId: 301,
+    createdAt: '2024-10-26',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuD7Pg_GffqU4AE_Ze3agQyd1yhST4WQTOOmLTkAnBP1VSdNXgsUF51wEbVRCfu8L-m1L-RRt75NmnXYS3kttvoO14JHiGT4qXPjKEngJ7e8QRwUKh2z0GbhleqheavIkiEVWe8bL1wI97vBEpUK8065rXBIQtDeosjZbYXj8t9QmHAiL0CjbD6OP7dKhqB01Y-XJVHk4oYQ0JDhWeGmwq3ssfTbwHPJzP5l0-aP86LfWL-eL_IvzsF37QS-yAvnRAGM5LjQ_RnJir4'],
+  },
+  {
+    postId: 18,
+    title: '길에서 떠도는 고양이 제보',
+    boardType: 'REPORT',
+    authorId: 302,
+    createdAt: '2024-10-25',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuDlJt2QC96OImZuGGTI88NtejEZgWWNasB3AHM3PLGpGXPH23FOTSx0tSivUqmZPHChJ3zYLc_B9t2r7ND4wedxJmKGTM_fpjKUqpoXG5ygaT6EE051Xsga9epHJujI9GH7xHuW5-0QUBRBNIlUWnH8fGaSIC09NHmykj1TA2bwT2XFnc43dX38M-FMNHaM7Be0vYTRy31F2jaDc9gfTUzOIEdYxlo5PsYDSkXnHUL3RpdxqG5wLyn1pJtX2899TJXCQBfhhwy88D0'],
+  },
+  {
+    postId: 19,
+    title: '상처 입은 강아지 발견 제보',
+    boardType: 'REPORT',
+    authorId: 303,
+    createdAt: '2024-10-24',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuAl-wzy55nASVdAoFA35PrgwSpNVb_c7CjEkeIMOIqgYvx6nQWEkmvFwjf26WdtS-Klq4xfyGTXu_6xaEsPfbdG3JOyrRaOvxqKWAY9TDTkcJlwhEEOPrRtQXXzu15Z1ItktS6zQSrEY-mkxlOnnmL2wXVUlM4mMsSrhMHQbmQ1hwTyFG9Klo1gm7d4-Wqjpu0xwmFIBkNFqe4aWYSSSLdM7FBvzTPcE1gXdk5G_YHHuJUSFtxn4gOst6pnh3tVmE3r70hOiAR1zNQ'],
+  },
+  {
+    postId: 20,
+    title: '공원에서 배회 중인 강아지',
+    boardType: 'REPORT',
+    authorId: 304,
+    createdAt: '2024-10-23',
+    imageUrls: ['https://lh3.googleusercontent.com/aida-public/AB6AXuCtSU28pG6PlzxwTplfEoBpUme_p6FbAln7lo46-pk8DcC-XVPrRSOBSeNYy8IuvdGQJbXhG340CoacxYL34QBOSQoQFamEPdguJHuW7_sdoJU2bTOTw0eA5spwlNeX36tBkKuWauGtmdI1S1F_IGNLCOgzO_0Bm1D9gAwxk0Om87dNXIHecV2PkKipLfUjEgMb5HsmSq8rHLEe_1PM7FweUt_qMEdl06cu9hH1EkQ0T1rxVb_-4rdRfColFn-9cQbllxPJ4HWO7qw'],
+  },
+  // 자유 게시판 목데이터
+  {
+    postId: 9,
+    title: '강아지 사료 추천해주세요!',
+    boardType: 'FREE',
+    authorId: 201,
+    createdAt: '2024-10-26',
+    views: 152,
+  },
+  {
+    postId: 10,
+    title: '고양이랑 친해지는 법 공유해요',
+    boardType: 'FREE',
+    authorId: 202,
+    createdAt: '2024-10-25',
+    views: 201,
+  },
+  {
+    postId: 11,
+    title: '산책하기 좋은 장소 추천!',
+    boardType: 'FREE',
+    authorId: 203,
+    createdAt: '2024-10-25',
+    views: 88,
+  },
+  {
+    postId: 12,
+    title: '새로운 가족이 생겼어요!',
+    boardType: 'FREE',
+    authorId: 204,
+    createdAt: '2024-10-24',
+    views: 312,
+  },
+  {
+    postId: 13,
+    title: '유기동물 봉사활동 후기',
+    boardType: 'FREE',
+    authorId: 205,
+    createdAt: '2024-10-23',
+    views: 450,
+  },
+  {
+    postId: 14,
+    title: '다들 반려동물 이름은 뭔가요?',
+    boardType: 'FREE',
+    authorId: 206,
+    createdAt: '2024-10-22',
+    views: 189,
+  },
+  {
+    postId: 15,
+    title: '고양이 츄르 뭐 먹이세요?',
+    boardType: 'FREE',
+    authorId: 207,
+    createdAt: '2024-10-22',
+    views: 233,
+  },
+  {
+    postId: 16,
+    title: '강아지 미용 어디가 잘하나요?',
+    boardType: 'FREE',
+    authorId: 208,
+    createdAt: '2024-10-21',
+    views: 110,
+  },
+];
+
+const boardTabs: { key: BoardType; label: string }[] = [
+  { key: 'MISSING', label: '실종 동물' },
+  { key: 'PROTECTION', label: '보호 동물' },
+  { key: 'REPORT', label: '제보' },
+  { key: 'FREE', label: '소통 게시판' },
+];
+
+export default function CommunityList() {
+  const [activeTab, setActiveTab] = useState<BoardType>('MISSING');
+  const filtered = useMemo(
+    () => mockPosts.filter((p) => p.boardType === activeTab),
+    [activeTab],
+  );
+
+  const resolveImage = (urls?: string[]) => {
+    const first = urls?.[0];
+    if (!first) return placeholderImg;
+    try {
+      const host = new URL(first).hostname;
+      if (host.includes('placeholder.com')) return placeholderImg;
+      return first;
+    } catch {
+      return placeholderImg;
+    }
+  };
+
+  return (
+    <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark font-display text-gray-800 dark:text-gray-200">
+      <Header />
+      <main className="flex-grow">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
+          {/* PageHeading */}
+          <div className="mb-6 md:mb-8">
+            <h1 className="text-4xl font-black leading-tight tracking-[-0.033em] text-[#111816] dark:text-white">
+              커뮤니티
+            </h1>
+          </div>
+
+          {/* Tabs */}
+          <div className="border-b border-gray-200 dark:border-gray-700">
+            <nav className="flex -mb-px gap-8">
+              {boardTabs.map((tab) => {
+                const active = activeTab === tab.key;
+                return (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => setActiveTab(tab.key)}
+                    className={`flex flex-col items-center justify-center border-b-[3px] pb-[13px] pt-4 transition-colors ${
+                      active
+                        ? 'border-primary text-[#111816] dark:text-white'
+                        : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200'
+                    }`}
+                  >
+                    <p className="text-sm font-bold leading-normal tracking-[0.015em]">{tab.label}</p>
+                  </button>
+                );
+              })}
+            </nav>
+          </div>
+
+          {/* Search and Action Bar */}
+          <div className="flex flex-col md:flex-row gap-4 items-center justify-between py-6">
+            <div className="w-full md:max-w-xs">
+              <label className="relative flex items-center">
+                <span className="material-symbols-outlined absolute left-3 text-gray-400 dark:text-gray-500">search</span>
+                <input
+                  className="form-input w-full pl-10 pr-4 py-2.5 rounded-lg border-none bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:ring-2 focus:ring-primary/50"
+                  placeholder="제목, 내용으로 검색"
+                  type="text"
+                />
+              </label>
+            </div>
+                  <div className="relative group w-full md:w-auto">
+                    <Link
+                      to={activeTab === 'FREE' ? '/community/new?boardType=FREE' : '/community/new'}
+                      className="w-full flex items-center justify-center gap-2 px-5 py-2.5 bg-primary text-gray-900 text-sm font-bold rounded-lg hover:bg-opacity-90 transition-colors"
+                    >
+                      <span className="material-symbols-outlined text-base">edit</span>
+                      <span>글쓰기</span>
+                    </Link>
+                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-max hidden group-hover:block bg-gray-800 text-white text-xs rounded-md py-1.5 px-3 whitespace-nowrap">
+                      글을 작성하려면 로그인이 필요해요.
+                      <div className="absolute left-1/2 -translate-x-1/2 top-full w-0 h-0 border-x-4 border-x-transparent border-t-4 border-t-gray-800"></div>
+                    </div>
+                  </div>
+          </div>
+
+          {/* Content: Table for FREE, Grid for others */}
+          {activeTab === 'FREE' ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+                <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+                  <tr>
+                    <th className="px-6 py-3 w-20 text-center" scope="col">
+                      번호
+                    </th>
+                    <th className="px-6 py-3" scope="col">
+                      제목
+                    </th>
+                    <th className="px-6 py-3 w-32 text-center" scope="col">
+                      작성자
+                    </th>
+                    <th className="px-6 py-3 w-32 text-center" scope="col">
+                      작성일
+                    </th>
+                    <th className="px-6 py-3 w-24 text-center" scope="col">
+                      조회수
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((post, idx) => (
+                    <tr
+                      key={post.postId}
+                      onClick={() => (window.location.href = `/community/${post.postId}`)}
+                      className="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors cursor-pointer"
+                    >
+                      <td className="px-6 py-4 text-center text-gray-500 dark:text-gray-400">{filtered.length - idx}</td>
+                      <th className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white" scope="row">
+                        {post.title}
+                      </th>
+                      <td className="px-6 py-4 text-center">작성자ID</td>
+                      <td className="px-6 py-4 text-center">{post.createdAt}</td>
+                      <td className="px-6 py-4 text-center">{post.views || 0}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {filtered.map((post) => (
+                <Link key={post.postId} to={`/community/${post.postId}`} className="flex flex-col gap-3 group">
+                  <div
+                    className="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-lg overflow-hidden transform transition-transform duration-300 group-hover:scale-105"
+                    style={{ backgroundImage: `url(${resolveImage(post.imageUrls)})` }}
+                  />
+                  <div>
+                    <p className="text-base font-medium leading-normal text-[#111816] dark:text-white truncate">
+                      {post.title}
+                    </p>
+                    <p className="text-sm font-normal leading-normal text-gray-500 dark:text-gray-400">
+                      작성자 ID · {post.createdAt}
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+
+          {/* Pagination */}
+          <div className="flex justify-center mt-12">
+            <nav className="flex items-center gap-2">
+              <button className="flex items-center justify-center h-9 w-9 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-500 dark:text-gray-400">
+                <span className="material-symbols-outlined text-xl">chevron_left</span>
+              </button>
+              <button className="flex items-center justify-center h-9 w-9 rounded-lg bg-primary text-gray-900 text-sm font-bold">
+                1
+              </button>
+              <button className="flex items-center justify-center h-9 w-9 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-sm font-medium text-gray-600 dark:text-gray-300">
+                2
+              </button>
+              <button className="flex items-center justify-center h-9 w-9 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-sm font-medium text-gray-600 dark:text-gray-300">
+                3
+              </button>
+              <button className="flex items-center justify-center h-9 w-9 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-500 dark:text-gray-400">
+                <span className="material-symbols-outlined text-xl">chevron_right</span>
+              </button>
+            </nav>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
- 커뮤니티 페이지 구현 (실종/보호/제보/소통게시판)
- 입양 후기 페이지 구현
- 소통게시판 전용 디자인 레이아웃 적용
- Header 네비게이션에 커뮤니티, 입양후기 링크 추가
- App.tsx에 커뮤니티 및 입양 후기 라우트 추가
- CommunityCreate.tsx: 사용하지 않는 import 제거
- CommunityDetail.tsx: map 파라미터 타입 명시