### PR TITLE
fix: 관리자 대시보드 접근 권한 복구

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,7 +163,13 @@ function App() {
       />
       <Route
         path="/admin/dashboard"
-        element={<AdminDashboard />}
+        element={
+          <ProtectedRoute>
+            <AdminRoute>
+              <AdminDashboard />
+            </AdminRoute>
+          </ProtectedRoute>
+        }
       />
       <Route
         path="/cart"


### PR DESCRIPTION
## 변경 사항
- 관리자 대시보드 페이지에 접근 권한 제어 복구
  - `ProtectedRoute` 적용 (로그인 필수)
  - `AdminRoute` 적용 (관리자 권한 필수)
  - 비로그인 사용자 및 일반 사용자 접근 차단

## 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- 디자인 확인을 위해 임시로 제거했던 접근 권한 제어를 복구했습니다.
- 이제 관리자만 `/admin/dashboard`에 접근할 수 있습니다.