### PR TITLE
feat: 관리자용 상품 수정 및 목록 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import AnimalDetail from './pages/AnimalDetail.tsx';
 import Products from './pages/Products.tsx';
 import ProductDetail from './pages/ProductDetail.tsx';
 import ProductCreate from './pages/ProductCreate.tsx';
+import ProductEdit from './pages/ProductEdit.tsx';
+import AdminProductList from './pages/AdminProductList.tsx';
 import AdminDashboard from './pages/AdminDashboard.tsx';
 import AdminCategoryManagement from './pages/AdminCategoryManagement.tsx';
 import AdminOptionGroupManagement from './pages/AdminOptionGroupManagement.tsx';
@@ -159,6 +161,26 @@ function App() {
           <ProtectedRoute>
             <AdminRoute>
               <ProductCreate />
+            </AdminRoute>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/admin/products"
+        element={
+          <ProtectedRoute>
+            <AdminRoute>
+              <AdminProductList />
+            </AdminRoute>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/admin/products/:productId/edit"
+        element={
+          <ProtectedRoute>
+            <AdminRoute>
+              <ProductEdit />
             </AdminRoute>
           </ProtectedRoute>
         }

--- a/src/api/products.api.ts
+++ b/src/api/products.api.ts
@@ -19,12 +19,15 @@ import type {
   UpdateOptionGroupRequest,
   CreateOptionValueRequest,
   UpdateOptionValueRequest,
-  OptionValue
+  OptionValue,
+  UpdateProductRequest
 } from '../types/api.types';
 
 // 상품 목록 검색
 export const getProducts = async (params?: ProductSearchParams): Promise<ProductSearchResponse> => {
   const response = await apiClient.get<ProductSearchResponse>('/api/products', { params });
+  console.log('getProducts API 응답:', response.data);
+  console.log('요청 파라미터:', params);
   return response.data;
 };
 
@@ -170,5 +173,16 @@ export const updateOptionValue = async (valueId: number, valueData: UpdateOption
 // 옵션 값 삭제
 export const deleteOptionValue = async (valueId: number): Promise<void> => {
   await apiClient.delete(`/api/option-groups/values/${valueId}`);
+};
+
+// 상품 수정
+export const updateProduct = async (productId: number, productData: UpdateProductRequest): Promise<Product> => {
+  const response = await apiClient.patch<Product>(`/api/products/${productId}`, productData);
+  return response.data;
+};
+
+// 상품 삭제 (소프트 삭제)
+export const deleteProduct = async (productId: number): Promise<void> => {
+  await apiClient.delete(`/api/products/${productId}`);
 };
 

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -221,9 +221,13 @@ export default function AdminDashboard() {
             </button>
             {isProductMenuOpen && (
               <div className="flex flex-col mt-1 gap-1">
-                <button className="pl-11 flex items-center gap-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary hover:text-text-main dark:hover:text-white transition-colors text-sm">
+                <Link
+                  to="/admin/products"
+                  className="pl-11 flex items-center gap-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary hover:text-text-main dark:hover:text-white transition-colors text-sm"
+                  onClick={() => setIsProductMenuOpen(false)}
+                >
                   상품 목록
-                </button>
+                </Link>
                 <Link
                   to="/products/new"
                   className="pl-11 flex items-center gap-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary hover:text-text-main dark:hover:text-white transition-colors text-sm"

--- a/src/pages/AdminProductList.tsx
+++ b/src/pages/AdminProductList.tsx
@@ -1,0 +1,351 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getProducts, deleteProduct } from '../api/products.api';
+import type { ProductSearchParams, ProductStatus } from '../types/api.types';
+import { useAuthStore } from '../store/authStore';
+
+export default function AdminProductList() {
+  const navigate = useNavigate();
+  const { logout } = useAuthStore();
+  const queryClient = useQueryClient();
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [statusFilter, setStatusFilter] = useState<ProductStatus | 'ALL'>('ALL');
+
+  // 검색 파라미터
+  const searchParams: ProductSearchParams = {
+    page: 0,
+    size: 20,
+    sortBy: 'createdAt',
+    sortOrder: 'desc',
+    ...(searchKeyword && { keyword: searchKeyword }),
+    ...(statusFilter !== 'ALL' && { status: statusFilter }),
+  };
+
+  // 상품 목록 조회
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-products', searchParams],
+    queryFn: () => getProducts(searchParams),
+  });
+
+  // 디버깅: API 응답 확인
+  console.log('상품 목록 API 응답:', { data, isLoading, error });
+  console.log('검색 파라미터:', searchParams);
+
+  // 상품 삭제 mutation
+  const deleteProductMutation = useMutation({
+    mutationFn: deleteProduct,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-products'] });
+      alert('상품이 삭제되었습니다.');
+    },
+    onError: (error: any) => {
+      alert(`상품 삭제 실패: ${error.response?.data?.message || error.message}`);
+    },
+  });
+
+  // 삭제 확인
+  const handleDelete = (productId: number) => {
+    if (window.confirm('정말로 이 상품을 삭제하시겠습니까?')) {
+      deleteProductMutation.mutate(productId);
+    }
+  };
+
+  // 상태 필터 버튼 클릭
+  const handleStatusFilter = (status: ProductStatus | 'ALL') => {
+    setStatusFilter(status);
+  };
+
+  // 날짜 포맷팅
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return '';
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  };
+
+  // 상태 배지 스타일
+  const getStatusBadge = (status: ProductStatus) => {
+    const statusMap = {
+      ACTIVE: {
+        label: '판매중',
+        className: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 border-green-200 dark:border-green-800',
+      },
+      SOLD_OUT: {
+        label: '품절',
+        className: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400 border-orange-200 dark:border-orange-800',
+      },
+      INACTIVE: {
+        label: '비활성',
+        className: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400 border-gray-200 dark:border-gray-800',
+      },
+      HIDDEN: {
+        label: '숨김',
+        className: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400 border-gray-200 dark:border-gray-800',
+      },
+      DELETED: {
+        label: '삭제됨',
+        className: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800',
+      },
+    };
+    return statusMap[status] || statusMap.INACTIVE;
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
+  return (
+    <div className="bg-background-light dark:bg-background-dark font-display text-text-main dark:text-gray-100 transition-colors duration-200 flex h-screen w-full overflow-hidden">
+      {/* Sidebar */}
+      <aside className="w-64 bg-surface-light dark:bg-surface-dark border-r border-[#dbe6e3] dark:border-[#2a3c38] flex-shrink-0 flex flex-col transition-colors duration-200 z-20 hidden md:flex">
+        <div className="p-6 flex items-center gap-3">
+          <div className="bg-primary/20 bg-center bg-no-repeat bg-cover rounded-full size-10 flex items-center justify-center text-primary-content">
+            <span className="material-symbols-outlined">pets</span>
+          </div>
+          <div className="flex flex-col">
+            <h1 className="text-text-main dark:text-white text-lg font-bold leading-tight">PawBridge</h1>
+            <p className="text-text-sub dark:text-gray-400 text-xs font-medium">관리자 센터</p>
+          </div>
+        </div>
+        <nav className="flex-1 overflow-y-auto px-4 py-2 flex flex-col gap-2">
+          <Link
+            to="/admin/dashboard"
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-main dark:text-gray-200 hover:bg-background-light dark:hover:bg-background-dark transition-colors"
+          >
+            <span className="material-symbols-outlined text-text-sub dark:text-gray-400">dashboard</span>
+            <span className="text-sm font-medium">대시보드</span>
+          </Link>
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-3 px-3 py-2.5 rounded-lg bg-primary/10 text-primary-content dark:text-primary font-medium">
+              <span className="material-symbols-outlined fill-current">inventory_2</span>
+              <span className="text-sm">상품 관리</span>
+            </div>
+            <div className="pl-11 pr-3 flex flex-col gap-1">
+              <Link
+                to="/admin/products"
+                className="py-2 text-sm font-bold text-primary dark:text-primary"
+              >
+                상품 목록
+              </Link>
+              <Link
+                to="/products/new"
+                className="py-2 text-sm text-text-sub dark:text-gray-400 hover:text-text-main dark:hover:text-gray-200 transition-colors"
+              >
+                상품 등록
+              </Link>
+            </div>
+          </div>
+          <Link
+            to="/admin/categories"
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-main dark:text-gray-200 hover:bg-background-light dark:hover:bg-background-dark transition-colors"
+          >
+            <span className="material-symbols-outlined text-text-sub dark:text-gray-400">category</span>
+            <span className="text-sm font-medium">카테고리 관리</span>
+          </Link>
+        </nav>
+        <div className="p-4 border-t border-[#dbe6e3] dark:border-[#2a3c38]">
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-3 px-3 py-2 text-text-sub dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors w-full"
+          >
+            <span className="material-symbols-outlined">logout</span>
+            <span className="text-sm font-medium">로그아웃</span>
+          </button>
+        </div>
+      </aside>
+
+      {/* Main Content */}
+      <main className="flex-1 flex flex-col h-full overflow-hidden relative">
+        {/* Mobile Header */}
+        <header className="md:hidden flex items-center justify-between p-4 bg-surface-light dark:bg-surface-dark border-b border-[#dbe6e3] dark:border-[#2a3c38]">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined text-primary">pets</span>
+            <span className="font-bold">PawBridge</span>
+          </div>
+          <button className="text-text-main dark:text-white">
+            <span className="material-symbols-outlined">menu</span>
+          </button>
+        </header>
+
+        {/* Page Content Scrollable Area */}
+        <div className="flex-1 overflow-y-auto p-4 md:p-8 lg:p-10 scroll-smooth">
+          <div className="max-w-7xl mx-auto flex flex-col gap-6">
+            {/* Page Heading */}
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
+              <div className="flex flex-col gap-2">
+                <h2 className="text-3xl font-bold text-text-main dark:text-white tracking-tight">상품 목록</h2>
+                <p className="text-text-sub dark:text-gray-400 text-sm">등록된 상품을 조회하고 재고 및 상태를 관리합니다.</p>
+              </div>
+              <Link
+                to="/products/new"
+                className="flex items-center justify-center gap-2 bg-primary hover:bg-emerald-300 text-primary-content px-5 py-2.5 rounded-lg font-bold text-sm transition-all shadow-sm hover:shadow-md"
+              >
+                <span className="material-symbols-outlined text-[20px]">add</span>
+                <span>상품 등록</span>
+              </Link>
+            </div>
+
+            {/* Filter & Search Bar */}
+            <div className="bg-surface-light dark:bg-surface-dark rounded-xl p-4 shadow-sm border border-[#dbe6e3] dark:border-[#2a3c38] flex flex-col lg:flex-row gap-4 justify-between items-start lg:items-center">
+              {/* Search */}
+              <div className="relative w-full lg:w-96 group">
+                <input
+                  type="text"
+                  value={searchKeyword}
+                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  placeholder="상품명으로 검색하세요"
+                  className="w-full h-11 pl-11 pr-4 rounded-lg bg-background-light dark:bg-background-dark border-[#dbe6e3] dark:border-[#2a3c38] focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all text-sm text-text-main dark:text-white placeholder:text-text-sub"
+                />
+                <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-text-sub group-focus-within:text-primary transition-colors">search</span>
+              </div>
+              {/* Filters */}
+              <div className="flex flex-wrap items-center gap-2 w-full lg:w-auto">
+                <span className="text-xs font-semibold text-text-sub dark:text-gray-500 uppercase mr-1">상태 필터:</span>
+                <button
+                  onClick={() => handleStatusFilter('ALL')}
+                  className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+                    statusFilter === 'ALL'
+                      ? 'bg-primary text-primary-content border-transparent shadow-sm'
+                      : 'bg-white dark:bg-background-dark text-text-sub border-[#dbe6e3] dark:border-[#2a3c38] hover:border-primary dark:hover:border-primary'
+                  }`}
+                >
+                  전체
+                </button>
+                <button
+                  onClick={() => handleStatusFilter('ACTIVE')}
+                  className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+                    statusFilter === 'ACTIVE'
+                      ? 'bg-primary text-primary-content border-transparent shadow-sm'
+                      : 'bg-white dark:bg-background-dark text-text-sub border-[#dbe6e3] dark:border-[#2a3c38] hover:border-primary dark:hover:border-primary'
+                  }`}
+                >
+                  판매중
+                </button>
+                <button
+                  onClick={() => handleStatusFilter('SOLD_OUT')}
+                  className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+                    statusFilter === 'SOLD_OUT'
+                      ? 'bg-primary text-primary-content border-transparent shadow-sm'
+                      : 'bg-white dark:bg-background-dark text-text-sub border-[#dbe6e3] dark:border-[#2a3c38] hover:border-primary dark:hover:border-primary'
+                  }`}
+                >
+                  품절
+                </button>
+                <button
+                  onClick={() => handleStatusFilter('HIDDEN')}
+                  className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+                    statusFilter === 'HIDDEN'
+                      ? 'bg-primary text-primary-content border-transparent shadow-sm'
+                      : 'bg-white dark:bg-background-dark text-text-sub border-[#dbe6e3] dark:border-[#2a3c38] hover:border-primary dark:hover:border-primary'
+                  }`}
+                >
+                  숨김
+                </button>
+              </div>
+            </div>
+
+            {/* Data Table */}
+            <div className="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm border border-[#dbe6e3] dark:border-[#2a3c38] overflow-hidden">
+              <div className="overflow-x-auto">
+                {isLoading ? (
+                  <div className="p-8 text-center text-text-sub">로딩 중...</div>
+                ) : error ? (
+                  <div className="p-8 text-center text-red-600">
+                    <p>상품 목록을 불러올 수 없습니다.</p>
+                    <p className="text-xs mt-2 text-gray-500">{String(error)}</p>
+                  </div>
+                ) : !data?.items || data.items.length === 0 ? (
+                  <div className="p-8 text-center text-text-sub">
+                    등록된 상품이 없습니다.
+                    {data && <p className="text-xs mt-2">응답 데이터: {JSON.stringify(data)}</p>}
+                  </div>
+                ) : (
+                  <table className="w-full text-left border-collapse">
+                    <thead>
+                      <tr className="bg-background-light dark:bg-background-dark border-b border-[#dbe6e3] dark:border-[#2a3c38]">
+                        <th className="py-4 px-6 text-xs font-bold text-text-sub dark:text-gray-400 uppercase tracking-wider w-16">번호</th>
+                        <th className="py-4 px-6 text-xs font-bold text-text-sub dark:text-gray-400 uppercase tracking-wider min-w-[240px]">상품명</th>
+                        <th className="py-4 px-6 text-xs font-bold text-text-sub dark:text-gray-400 uppercase tracking-wider w-32">가격</th>
+                        <th className="py-4 px-6 text-xs font-bold text-text-sub dark:text-gray-400 uppercase tracking-wider w-24">재고</th>
+                        <th className="py-4 px-6 text-xs font-bold text-text-sub dark:text-gray-400 uppercase tracking-wider w-32 text-center">상태</th>
+                        <th className="py-4 px-6 text-xs font-bold text-text-sub dark:text-gray-400 uppercase tracking-wider w-32">등록일</th>
+                        <th className="py-4 px-6 text-xs font-bold text-text-sub dark:text-gray-400 uppercase tracking-wider w-28 text-right">관리</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-[#dbe6e3] dark:divide-[#2a3c38]">
+                      {data.items.map((item, index) => {
+                        const statusBadge = getStatusBadge(item.status || 'INACTIVE');
+                        return (
+                          <tr key={item.id} className="group hover:bg-background-light dark:hover:bg-background-dark/50 transition-colors">
+                            <td className="py-4 px-6 text-sm text-text-sub dark:text-gray-400 font-medium">{index + 1}</td>
+                            <td className="py-4 px-6">
+                              <div className="flex items-center gap-3">
+                                {item.imageUrl && (
+                                  <div
+                                    className="w-10 h-10 rounded-lg bg-gray-100 dark:bg-gray-800 bg-cover bg-center border border-[#dbe6e3] dark:border-[#2a3c38]"
+                                    style={{ backgroundImage: `url(${item.imageUrl})` }}
+                                  />
+                                )}
+                                <div className="flex flex-col">
+                                  <span className="text-sm font-bold text-text-main dark:text-gray-200 group-hover:text-primary transition-colors">
+                                    {item.name}
+                                  </span>
+                                  {item.optionName && (
+                                    <span className="text-xs text-text-sub dark:text-gray-500">{item.optionName}</span>
+                                  )}
+                                </div>
+                              </div>
+                            </td>
+                            <td className="py-4 px-6 text-sm font-semibold text-text-main dark:text-gray-200">
+                              {item.price?.toLocaleString() || 0}원
+                            </td>
+                            <td className="py-4 px-6 text-sm text-text-sub dark:text-gray-400">
+                              {item.totalStock !== undefined ? `${item.totalStock}개` : '-'}
+                            </td>
+                            <td className="py-4 px-6 text-center">
+                              <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${statusBadge.className}`}>
+                                {statusBadge.label}
+                              </span>
+                            </td>
+                            <td className="py-4 px-6 text-sm text-text-sub dark:text-gray-400">
+                              {item.createdAt ? formatDate(item.createdAt) : '-'}
+                            </td>
+                            <td className="py-4 px-6 text-right">
+                              <div className="flex items-center justify-end gap-2">
+                                <Link
+                                  to={`/admin/products/${item.id}/edit`}
+                                  className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-text-sub hover:text-primary transition-colors"
+                                  title="수정"
+                                >
+                                  <span className="material-symbols-outlined text-[20px]">edit</span>
+                                </Link>
+                                <button
+                                  onClick={() => handleDelete(item.id)}
+                                  disabled={deleteProductMutation.isPending}
+                                  className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-text-sub hover:text-red-500 transition-colors disabled:opacity-50"
+                                  title="삭제"
+                                >
+                                  <span className="material-symbols-outlined text-[20px]">delete</span>
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+

--- a/src/pages/ProductEdit.tsx
+++ b/src/pages/ProductEdit.tsx
@@ -1,0 +1,606 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams, Link } from 'react-router-dom';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { getProductById, updateProduct, deleteProduct, getCategories, uploadImage } from '../api/products.api';
+import type { Product, UpdateProductRequest, UpdateSku, CategoryResponse } from '../types/api.types';
+import CustomSelect from '../components/common/CustomSelect';
+
+export default function ProductEdit() {
+  const navigate = useNavigate();
+  const { productId } = useParams<{ productId: string }>();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  // 상품 정보 조회
+  const { data: product, isLoading: isLoadingProduct, error: productError } = useQuery<Product>({
+    queryKey: ['product', productId],
+    queryFn: () => getProductById(Number(productId)),
+    enabled: !!productId,
+  });
+
+  // 카테고리 목록 조회
+  const { data: categories = [] } = useQuery<CategoryResponse[]>({
+    queryKey: ['categories'],
+    queryFn: () => getCategories(),
+  });
+
+  // 폼 상태
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState<'ACTIVE' | 'INACTIVE' | 'SOLD_OUT'>('ACTIVE');
+  const [categoryId, setCategoryId] = useState<number | ''>('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string>('');
+  const [skus, setSkus] = useState<Array<UpdateSku & { skuId: number; skuCode: string; options: Record<string, string> }>>([]);
+
+  // 상품 정보 로드 시 폼 초기화
+  useEffect(() => {
+    if (product) {
+      setName(product.name);
+      setDescription(product.description);
+      setStatus(product.status as 'ACTIVE' | 'INACTIVE' | 'SOLD_OUT');
+      setCategoryId(product.categoryId || '');
+      setImagePreview(product.imageUrl);
+      
+      // SKU 정보 설정
+      if (product.skus) {
+        setSkus(product.skus.map(sku => ({
+          id: sku.skuId,
+          skuId: sku.skuId,
+          skuCode: sku.skuCode,
+          price: sku.price,
+          stockQuantity: sku.stockQuantity,
+          options: sku.options,
+        })));
+      }
+    }
+  }, [product]);
+
+  // 이미지 파일 선택
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      if (file.size > 5 * 1024 * 1024) {
+        alert('이미지 파일 크기는 5MB 이하여야 합니다.');
+        return;
+      }
+      const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
+      if (!allowedTypes.includes(file.type.toLowerCase())) {
+        alert('지원하는 이미지 형식은 JPEG, PNG, GIF, WEBP입니다.');
+        return;
+      }
+      setImageFile(file);
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImagePreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  // 이미지 제거
+  const handleRemoveImage = () => {
+    setImageFile(null);
+    setImagePreview(product?.imageUrl || '');
+  };
+
+  // SKU 가격 변경
+  const handleSkuPriceChange = (index: number, price: number) => {
+    const updated = [...skus];
+    updated[index].price = price;
+    setSkus(updated);
+  };
+
+  // SKU 재고 변경
+  const handleSkuStockChange = (index: number, stockQuantity: number) => {
+    const updated = [...skus];
+    updated[index].stockQuantity = stockQuantity;
+    setSkus(updated);
+  };
+
+  // 이미지 업로드 mutation
+  const uploadImageMutation = useMutation({
+    mutationFn: uploadImage,
+  });
+
+  // 상품 수정 mutation
+  const updateProductMutation = useMutation({
+    mutationFn: async (data: UpdateProductRequest) => {
+      return updateProduct(Number(productId), data);
+    },
+    onSuccess: () => {
+      alert('상품이 성공적으로 수정되었습니다.');
+      navigate('/admin/products');
+    },
+    onError: (error: any) => {
+      alert(`상품 수정 실패: ${error.response?.data?.message || error.message}`);
+    },
+  });
+
+  // 상품 삭제 mutation
+  const deleteProductMutation = useMutation({
+    mutationFn: () => deleteProduct(Number(productId)),
+    onSuccess: () => {
+      alert('상품이 삭제되었습니다.');
+      navigate('/admin/products');
+    },
+    onError: (error: any) => {
+      alert(`상품 삭제 실패: ${error.response?.data?.message || error.message}`);
+      setShowDeleteModal(false);
+    },
+  });
+
+  // 폼 제출
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) {
+      alert('상품명을 입력해주세요.');
+      return;
+    }
+
+    if (!categoryId) {
+      alert('카테고리를 선택해주세요.');
+      return;
+    }
+
+    try {
+      let imageUrl = product?.imageUrl || '';
+
+      // 새 이미지가 있으면 업로드
+      if (imageFile) {
+        const uploadResult = await uploadImageMutation.mutateAsync(imageFile);
+        imageUrl = uploadResult.imageUrl;
+      }
+
+      // SKU 데이터 준비 (id 필수)
+      const skuData: UpdateSku[] = skus.map(sku => ({
+        id: sku.id,
+        price: sku.price,
+        stockQuantity: sku.stockQuantity,
+      }));
+
+      const updateData: UpdateProductRequest = {
+        name,
+        description,
+        status,
+        categoryId: Number(categoryId),
+        imageUrl,
+        skus: skuData,
+      };
+
+      await updateProductMutation.mutateAsync(updateData);
+    } catch (error) {
+      console.error('상품 수정 실패:', error);
+    }
+  };
+
+  // 삭제 확인
+  const handleDelete = () => {
+    deleteProductMutation.mutate();
+  };
+
+  // 날짜 포맷팅
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return '';
+    const date = new Date(dateString);
+    return date.toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  if (isLoadingProduct) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-text-secondary">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (productError || !product) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-red-600">상품을 불러올 수 없습니다.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-background-light dark:bg-background-dark text-text-main font-sans min-h-screen flex overflow-hidden">
+      {/* 사이드바 */}
+      <aside className="w-64 bg-surface-light dark:bg-surface-dark border-r border-[#e0e8e5] dark:border-[#1f3530] flex flex-col flex-shrink-0 z-50">
+        <div className="h-16 flex items-center gap-3 px-6 border-b border-[#e0e8e5] dark:border-[#1f3530]">
+          <div className="size-8 text-primary">
+            <svg className="w-full h-full" fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+              <g clipPath="url(#clip0_6_330)">
+                <path clipRule="evenodd" d="M24 0.757355L47.2426 24L24 47.2426L0.757355 24L24 0.757355ZM21 35.7574V12.2426L9.24264 24L21 35.7574Z" fill="currentColor" fillRule="evenodd"></path>
+              </g>
+              <defs>
+                <clipPath id="clip0_6_330"><rect fill="white" height="48" width="48"></rect></clipPath>
+              </defs>
+            </svg>
+          </div>
+          <h1 className="text-xl font-display font-bold tracking-tight text-[#111816] dark:text-white">PawBridge</h1>
+        </div>
+        
+        <nav className="flex-1 overflow-y-auto py-6 px-3 flex flex-col gap-1 scrollbar-hide">
+          <Link to="/admin/dashboard" className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-text-secondary hover:bg-background-light hover:text-text-main transition-colors group">
+            <span className="material-symbols-outlined text-[24px]">dashboard</span>
+            <span className="text-sm font-medium">대시보드</span>
+          </Link>
+          <div className="py-2">
+            <div className="flex items-center gap-3 rounded-lg bg-primary/10 px-3 py-2.5 text-text-main transition-colors">
+              <span className="material-symbols-outlined text-[24px] text-primary-dark">inventory_2</span>
+              <span className="text-sm font-bold">상품 관리</span>
+            </div>
+            <div className="mt-1 flex flex-col space-y-1 pl-12 pr-2">
+              <Link to="/admin/products" className="rounded-md px-2 py-1.5 text-sm font-medium text-primary-dark bg-white/50 dark:bg-black/20">
+                상품 목록
+              </Link>
+              <Link to="/products/new" className="rounded-md px-2 py-1.5 text-sm font-medium text-text-secondary hover:text-text-main transition-colors">
+                상품 등록
+              </Link>
+            </div>
+          </div>
+          <Link to="/admin/categories" className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-text-secondary hover:bg-background-light hover:text-text-main transition-colors group">
+            <span className="material-symbols-outlined text-[24px]">category</span>
+            <span className="text-sm font-medium">카테고리 관리</span>
+          </Link>
+        </nav>
+      </aside>
+
+      {/* 메인 콘텐츠 */}
+      <main className="flex flex-1 flex-col overflow-y-auto">
+        {/* 헤더 */}
+        <header className="sticky top-0 z-10 flex h-16 items-center justify-between border-b border-[#e0e8e5] dark:border-[#1f3530] bg-surface-light/80 dark:bg-surface-dark/80 px-6 backdrop-blur-md">
+          <div className="flex items-center gap-2 text-sm">
+            <Link to="/" className="text-text-secondary hover:text-primary transition-colors">홈</Link>
+            <span className="text-text-secondary">/</span>
+            <Link to="/admin/products" className="text-text-secondary hover:text-primary transition-colors">상품 관리</Link>
+            <span className="text-text-secondary">/</span>
+            <Link to="/admin/products" className="text-text-secondary hover:text-primary transition-colors">상품 목록</Link>
+            <span className="text-text-secondary">/</span>
+            <span className="font-medium text-text-main dark:text-white">상품 수정</span>
+          </div>
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => setShowDeleteModal(true)}
+              className="flex items-center justify-center gap-2 rounded-lg px-4 py-2 bg-red-500 hover:bg-red-600 text-white text-sm font-bold transition-colors"
+            >
+              <span className="material-symbols-outlined text-[18px]">delete</span>
+              삭제
+            </button>
+          </div>
+        </header>
+
+        <div className="flex-1 p-6 lg:px-12 lg:py-8 max-w-[1200px] mx-auto w-full">
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold tracking-tight text-text-main dark:text-white">상품 수정</h1>
+            <p className="mt-1 text-sm text-text-secondary">상품의 상세 정보와 옵션별 재고 상태를 수정합니다.</p>
+          </div>
+
+          <form onSubmit={handleSubmit}>
+            <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+              {/* 왼쪽: 기본 정보 및 SKU */}
+              <div className="flex flex-col gap-6 lg:col-span-2">
+                {/* 기본 정보 */}
+                <div className="rounded-2xl border border-[#e0e8e5] dark:border-gray-700 bg-white dark:bg-surface-dark p-6 shadow-sm">
+                  <h3 className="mb-5 text-lg font-bold text-text-main dark:text-white flex items-center gap-2">
+                    <span className="material-symbols-outlined text-primary">edit_note</span>
+                    기본 정보
+                  </h3>
+                  
+                  {/* 상품 ID 및 생성일 */}
+                  <div className="mb-5 grid grid-cols-1 gap-5 sm:grid-cols-2 rounded-xl bg-background-light dark:bg-gray-800/50 p-4 border border-[#e0e8e5] dark:border-gray-600">
+                    <div>
+                      <label className="block text-xs font-bold text-text-secondary uppercase">상품 ID</label>
+                      <p className="mt-1 font-mono text-sm font-medium text-text-main dark:text-gray-300">#{product.productId}</p>
+                    </div>
+                    <div>
+                      <label className="block text-xs font-bold text-text-secondary uppercase">생성일</label>
+                      <p className="mt-1 font-mono text-sm font-medium text-text-main dark:text-gray-300">{formatDate(product.createdAt)}</p>
+                    </div>
+                  </div>
+
+                  <div className="space-y-5">
+                    {/* 상품명 */}
+                    <div>
+                      <label className="mb-2 block text-sm font-medium text-text-main dark:text-gray-200">상품명</label>
+                      <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        className="w-full rounded-lg border border-[#e0e8e5] dark:border-gray-600 bg-background-light dark:bg-gray-800 px-4 py-3 text-sm text-text-main focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary dark:text-white"
+                        required
+                      />
+                    </div>
+
+                    {/* 상품 상태 */}
+                    <div>
+                      <label className="mb-2 block text-sm font-medium text-text-main dark:text-gray-200">상품 상태</label>
+                      <div className="flex flex-wrap gap-3">
+                        <label className={`flex flex-1 items-center justify-center gap-2 rounded-lg border p-3 cursor-pointer transition-colors ${
+                          status === 'ACTIVE' 
+                            ? 'border-primary bg-primary/5 text-primary-dark' 
+                            : 'border-[#e0e8e5] dark:border-gray-600 hover:bg-background-light dark:hover:bg-gray-800'
+                        }`}>
+                          <input
+                            type="radio"
+                            name="product_status"
+                            value="ACTIVE"
+                            checked={status === 'ACTIVE'}
+                            onChange={() => setStatus('ACTIVE')}
+                            className="form-radio text-primary focus:ring-primary"
+                          />
+                          <span className="text-sm font-medium">활성</span>
+                        </label>
+                        <label className={`flex flex-1 items-center justify-center gap-2 rounded-lg border p-3 cursor-pointer transition-colors ${
+                          status === 'INACTIVE' 
+                            ? 'border-primary bg-primary/5 text-primary-dark' 
+                            : 'border-[#e0e8e5] dark:border-gray-600 hover:bg-background-light dark:hover:bg-gray-800'
+                        }`}>
+                          <input
+                            type="radio"
+                            name="product_status"
+                            value="INACTIVE"
+                            checked={status === 'INACTIVE'}
+                            onChange={() => setStatus('INACTIVE')}
+                            className="form-radio text-primary focus:ring-primary"
+                          />
+                          <span className="text-sm font-medium">비활성</span>
+                        </label>
+                        <label className={`flex flex-1 items-center justify-center gap-2 rounded-lg border p-3 cursor-pointer transition-colors ${
+                          status === 'SOLD_OUT' 
+                            ? 'border-primary bg-primary/5 text-primary-dark' 
+                            : 'border-[#e0e8e5] dark:border-gray-600 hover:bg-background-light dark:hover:bg-gray-800'
+                        }`}>
+                          <input
+                            type="radio"
+                            name="product_status"
+                            value="SOLD_OUT"
+                            checked={status === 'SOLD_OUT'}
+                            onChange={() => setStatus('SOLD_OUT')}
+                            className="form-radio text-primary focus:ring-primary"
+                          />
+                          <span className="text-sm font-medium">품절</span>
+                        </label>
+                      </div>
+                    </div>
+
+                    {/* 카테고리 */}
+                    <div>
+                      <label className="mb-2 block text-sm font-medium text-text-main dark:text-gray-200">카테고리</label>
+                      <CustomSelect
+                        value={categoryId}
+                        onChange={(value) => setCategoryId(typeof value === 'number' ? value : '')}
+                        options={categories.map(cat => ({ value: cat.id, label: cat.name }))}
+                        placeholder="카테고리 선택"
+                      />
+                    </div>
+
+                    {/* 상세 설명 */}
+                    <div>
+                      <label className="mb-2 block text-sm font-medium text-text-main dark:text-gray-200">상세 설명</label>
+                      <div className="relative rounded-lg border border-[#e0e8e5] dark:border-gray-600 bg-background-light dark:bg-gray-800">
+                        <div className="flex items-center gap-1 border-b border-[#e0e8e5] dark:border-gray-600 px-2 py-2">
+                          <button type="button" className="rounded p-1 text-text-secondary hover:bg-gray-200 hover:text-text-main dark:hover:bg-gray-700">
+                            <span className="material-symbols-outlined text-[20px]">format_bold</span>
+                          </button>
+                          <button type="button" className="rounded p-1 text-text-secondary hover:bg-gray-200 hover:text-text-main dark:hover:bg-gray-700">
+                            <span className="material-symbols-outlined text-[20px]">format_italic</span>
+                          </button>
+                          <button type="button" className="rounded p-1 text-text-secondary hover:bg-gray-200 hover:text-text-main dark:hover:bg-gray-700">
+                            <span className="material-symbols-outlined text-[20px]">format_list_bulleted</span>
+                          </button>
+                          <button type="button" className="rounded p-1 text-text-secondary hover:bg-gray-200 hover:text-text-main dark:hover:bg-gray-700">
+                            <span className="material-symbols-outlined text-[20px]">link</span>
+                          </button>
+                        </div>
+                        <textarea
+                          value={description}
+                          onChange={(e) => setDescription(e.target.value)}
+                          className="w-full resize-y rounded-b-lg border-none bg-transparent px-4 py-3 text-sm text-text-main focus:ring-0 dark:text-white min-h-[160px]"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* 옵션 및 재고 관리 (SKU) */}
+                <div className="rounded-2xl border border-[#e0e8e5] dark:border-gray-700 bg-white dark:bg-surface-dark p-6 shadow-sm">
+                  <div className="mb-5 flex flex-wrap items-center justify-between gap-4">
+                    <h3 className="text-lg font-bold text-text-main dark:text-white flex items-center gap-2">
+                      <span className="material-symbols-outlined text-primary">inventory</span>
+                      옵션 및 재고 관리 (SKU)
+                    </h3>
+                    <div className="flex items-center gap-2 rounded-full bg-orange-50 dark:bg-orange-900/20 px-3 py-1.5 text-xs text-orange-700 dark:text-orange-300 border border-orange-100 dark:border-orange-800">
+                      <span className="material-symbols-outlined text-[16px]">info</span>
+                      SKU ID, SKU 코드, 옵션 조합은 수정 불가
+                    </div>
+                  </div>
+
+                  <div className="overflow-x-auto rounded-xl border border-[#e0e8e5] dark:border-gray-600">
+                    <table className="w-full text-left text-sm">
+                      <thead className="bg-background-light dark:bg-gray-800">
+                        <tr>
+                          <th className="px-4 py-3 font-medium text-text-secondary dark:text-gray-400 w-24">SKU ID</th>
+                          <th className="px-4 py-3 font-medium text-text-secondary dark:text-gray-400">SKU 코드</th>
+                          <th className="px-4 py-3 font-medium text-text-secondary dark:text-gray-400">옵션 조합</th>
+                          <th className="px-4 py-3 font-medium text-text-secondary dark:text-gray-400 w-32">가격 (원)</th>
+                          <th className="px-4 py-3 font-medium text-text-secondary dark:text-gray-400 w-24">재고</th>
+                          <th className="px-4 py-3 font-medium text-text-secondary dark:text-gray-400 w-20 text-center">상태</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-[#e0e8e5] dark:divide-gray-600 bg-white dark:bg-surface-dark">
+                        {skus.map((sku, index) => (
+                          <tr key={sku.skuId} className="group hover:bg-background-light dark:hover:bg-gray-800 transition-colors">
+                            <td className="px-4 py-3 text-text-secondary font-mono text-xs bg-gray-50 dark:bg-gray-800/50">
+                              #{sku.skuId}
+                            </td>
+                            <td className="px-4 py-3 text-text-secondary font-mono text-xs bg-gray-50 dark:bg-gray-800/50">
+                              {sku.skuCode}
+                            </td>
+                            <td className="px-4 py-3 font-medium text-text-main dark:text-white bg-gray-50 dark:bg-gray-800/50">
+                              <div className="flex flex-col gap-1">
+                                {Object.entries(sku.options || {}).map(([key, value]) => (
+                                  <span key={key} className="text-xs text-text-secondary">
+                                    {key}: <span className="text-text-main dark:text-gray-200">{value}</span>
+                                  </span>
+                                ))}
+                              </div>
+                            </td>
+                            <td className="px-4 py-3">
+                              <input
+                                type="number"
+                                value={sku.price || 0}
+                                onChange={(e) => handleSkuPriceChange(index, Number(e.target.value))}
+                                className="w-full rounded border border-[#e0e8e5] dark:border-gray-600 px-2 py-1.5 text-right text-sm text-text-main focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary dark:bg-gray-700 dark:text-white"
+                                min="0"
+                              />
+                            </td>
+                            <td className="px-4 py-3">
+                              <input
+                                type="number"
+                                value={sku.stockQuantity || 0}
+                                onChange={(e) => handleSkuStockChange(index, Number(e.target.value))}
+                                className={`w-full rounded border px-2 py-1.5 text-right text-sm focus:outline-none focus:ring-1 ${
+                                  (sku.stockQuantity || 0) === 0
+                                    ? 'border-red-300 bg-red-50 text-red-600 focus:border-red-500 focus:ring-red-500 dark:bg-red-900/20 dark:border-red-800 dark:text-red-300'
+                                    : 'border-[#e0e8e5] dark:border-gray-600 text-text-main focus:border-primary focus:ring-primary dark:bg-gray-700 dark:text-white'
+                                }`}
+                                min="0"
+                              />
+                            </td>
+                            <td className="px-4 py-3 text-center">
+                              <div className="flex justify-center">
+                                <label className="relative inline-flex cursor-pointer items-center">
+                                  <input
+                                    type="checkbox"
+                                    checked={(sku.stockQuantity || 0) > 0}
+                                    readOnly
+                                    className="peer sr-only"
+                                  />
+                                  <div className="peer h-5 w-9 rounded-full bg-gray-200 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all after:content-[''] peer-checked:bg-primary peer-checked:after:translate-x-full peer-focus:outline-none dark:bg-gray-600"></div>
+                                </label>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+
+              {/* 오른쪽: 이미지 업로드 */}
+              <div className="flex flex-col gap-6">
+                <div className="rounded-2xl border border-[#e0e8e5] dark:border-gray-700 bg-white dark:bg-surface-dark p-6 shadow-sm">
+                  <h3 className="mb-5 text-lg font-bold text-text-main dark:text-white flex items-center gap-2">
+                    <span className="material-symbols-outlined text-primary">image</span>
+                    상품 이미지
+                  </h3>
+                  
+                  {imagePreview ? (
+                    <div className="space-y-4">
+                      <div className="relative aspect-square rounded-xl bg-gray-100 overflow-hidden group border border-[#e0e8e5] dark:border-gray-600">
+                        <img
+                          src={imagePreview}
+                          alt="상품 이미지"
+                          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                        />
+                        <button
+                          type="button"
+                          onClick={handleRemoveImage}
+                          className="absolute top-2 right-2 p-2 bg-red-500 hover:bg-red-600 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
+                        >
+                          <span className="material-symbols-outlined text-[18px]">delete</span>
+                        </button>
+                      </div>
+                      <label className="flex items-center justify-center gap-2 rounded-lg border-2 border-dashed border-primary/40 bg-primary/5 px-6 py-3 text-center cursor-pointer hover:border-primary hover:bg-primary/10 transition-colors">
+                        <span className="material-symbols-outlined text-primary">cloud_upload</span>
+                        <span className="text-sm font-medium text-text-main dark:text-white">이미지 변경</span>
+                        <input
+                          type="file"
+                          accept="image/*"
+                          onChange={handleImageChange}
+                          className="hidden"
+                        />
+                      </label>
+                    </div>
+                  ) : (
+                    <label className="group relative flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-primary/40 bg-primary/5 px-6 py-8 text-center transition-colors hover:border-primary hover:bg-primary/10 cursor-pointer">
+                      <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-primary/20 text-primary-dark group-hover:scale-110 transition-transform">
+                        <span className="material-symbols-outlined">cloud_upload</span>
+                      </div>
+                      <p className="text-sm font-medium text-text-main dark:text-white">클릭하여 이미지 업로드</p>
+                      <p className="mt-1 text-xs text-text-secondary">또는 이미지를 여기로 드래그하세요</p>
+                      <input
+                        type="file"
+                        accept="image/*"
+                        onChange={handleImageChange}
+                        className="hidden"
+                      />
+                    </label>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* 하단 버튼 */}
+            <div className="sticky bottom-6 z-20 mt-8 rounded-2xl border border-[#e0e8e5] dark:border-gray-700 bg-surface-light dark:bg-surface-dark p-4 shadow-xl shadow-gray-200/50 dark:shadow-black/20">
+              <div className="flex flex-col gap-3">
+                <button
+                  type="submit"
+                  disabled={updateProductMutation.isPending || uploadImageMutation.isPending}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3.5 text-sm font-bold text-text-main shadow-sm shadow-primary/30 transition-all hover:bg-primary-dark hover:shadow-primary/50 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50"
+                >
+                  <span className="material-symbols-outlined text-[20px]">save</span>
+                  수정 완료
+                </button>
+                <button
+                  type="button"
+                  onClick={() => navigate('/admin/products')}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-[#e0e8e5] dark:border-gray-600 bg-white dark:bg-gray-800 px-6 py-3.5 text-sm font-bold text-text-secondary transition-colors hover:bg-gray-50 hover:text-text-main dark:hover:bg-gray-700 dark:hover:text-white"
+                >
+                  취소
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </main>
+
+      {/* 삭제 확인 모달 */}
+      {showDeleteModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="relative z-10 mx-4 max-w-md rounded-2xl bg-white dark:bg-gray-900 shadow-xl border border-gray-200/80 dark:border-gray-700 p-6 flex flex-col gap-4">
+            <h3 className="text-xl font-bold text-text-main dark:text-white">상품 삭제 확인</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              정말로 이 상품을 삭제하시겠습니까?<br />
+              삭제된 상품은 검색/목록에서 제외되며, 장바구니에 담긴 상품은 삭제할 수 없습니다.
+            </p>
+            <div className="flex flex-col gap-3">
+              <button
+                onClick={handleDelete}
+                disabled={deleteProductMutation.isPending}
+                className="w-full inline-flex justify-center items-center rounded-lg h-11 bg-red-500 hover:bg-red-600 text-white text-sm font-bold transition-colors disabled:opacity-50"
+              >
+                {deleteProductMutation.isPending ? '삭제 중...' : '삭제'}
+              </button>
+              <button
+                onClick={() => setShowDeleteModal(false)}
+                className="w-full inline-flex justify-center items-center rounded-lg h-11 bg-gray-100 dark:bg-gray-800 text-text-main dark:text-gray-300 text-sm font-bold hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -176,7 +176,7 @@ export interface AnimalSearchParams {
 // ========== 상품(Store) 관련 타입 ==========
 
 // 상품 상태
-export type ProductStatus = 'ACTIVE' | 'INACTIVE' | 'SOLD_OUT';
+export type ProductStatus = 'ACTIVE' | 'INACTIVE' | 'SOLD_OUT' | 'HIDDEN' | 'DELETED';
 
 // 상품 카테고리
 export interface Category {
@@ -224,6 +224,7 @@ export interface ProductListItem {
   totalStock: number;
   imageUrl?: string;
   status?: ProductStatus;
+  createdAt?: string;          // 등록일
 }
 
 // 상품 검색 파라미터
@@ -324,6 +325,22 @@ export interface CreateProductRequest {
   imageUrl: string;
   categoryId: number;  // 카테고리 ID 필수
   skus: CreateSku[];
+}
+
+// 상품 수정 요청 (모든 필드 선택사항)
+export interface UpdateSku {
+  id?: number;  // 기존 SKU 수정 시 필수
+  price?: number;
+  stockQuantity?: number;
+}
+
+export interface UpdateProductRequest {
+  name?: string;
+  description?: string;
+  imageUrl?: string;
+  status?: ProductStatus;
+  categoryId?: number;
+  skus?: UpdateSku[];
 }
 
 // 장바구니 아이템


### PR DESCRIPTION
## 변경 사항
관리자가 상품을 조회, 수정, 삭제할 수 있는 페이지를 구현했습니다.

### 주요 기능
#### 상품 수정 페이지 (`/admin/products/:productId/edit`)
- 상품 기본 정보 수정 (이름, 설명, 상태, 카테고리)
- 이미지 업로드 및 변경
- SKU별 가격 및 재고 수정
- 헤더에 삭제 버튼 추가 (확인 모달 포함)
- SKU ID, SKU 코드, 옵션 조합은 수정 불가 처리 (회색 배경)
- 안내 문구: "SKU ID, SKU 코드, 옵션 조합은 수정 불가"

#### 상품 목록 페이지 (`/admin/products`)
- 상품명 검색 기능
- 상태 필터 (전체, 판매중, 품절, 숨김)
- 상품 목록 테이블 표시 (번호, 상품명, 가격, 재고, 상태, 등록일, 관리)
- 각 상품별 수정/삭제 버튼
- 상품 등록 버튼

### API 연동
- `PATCH /store-service/api/products/{productId}`: 상품 수정
- `DELETE /store-service/api/products/{productId}`: 상품 삭제 (소프트 삭제)
- `GET /store-service/api/products`: 상품 목록 조회 (검색, 필터링)

### 타입 정의
- `UpdateProductRequest`: 상품 수정 요청 타입
- `UpdateSku`: SKU 수정 타입
- `ProductStatus`: HIDDEN, DELETED 상태 추가
- `ProductListItem`: createdAt 필드 추가

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Closes #33 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- 상품 수정 페이지는 관리자 사이드바를 포함하여 구현했습니다.
- 삭제 기능은 소프트 삭제로 구현되어 있으며, 확인 모달을 통해 실수로 인한 삭제를 방지합니다.
- SKU 테이블에서 수정 불가 필드(SKU ID, SKU 코드, 옵션 조합)는 회색 배경으로 표시됩니다.
- 브랜드 필드는 API에 없어 제거했습니다.