### PR TITLE
feat: 로그인 페이지 UX 개선 및 관리자 페이지 사이드바 통일

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import Signup from './pages/Signup.tsx';
 import ResetPassword from './pages/ResetPassword.tsx';
 import Animals from './pages/Animals.tsx';
 import AnimalDetail from './pages/AnimalDetail.tsx';
+import AnimalCreate from './pages/AnimalCreate.tsx';
+import AnimalEdit from './pages/AnimalEdit.tsx';
 import Products from './pages/Products.tsx';
 import ProductDetail from './pages/ProductDetail.tsx';
 import ProductCreate from './pages/ProductCreate.tsx';
@@ -152,6 +154,22 @@ function App() {
       <Route path="/oauth/callback" element={<OAuthCallback />} />
       <Route path="/animals" element={<Animals />} />
       <Route path="/animals/:id" element={<AnimalDetail />} />
+      <Route
+        path="/animals/new"
+        element={
+          <ProtectedRoute>
+            <AnimalCreate />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/animals/:id/edit"
+        element={
+          <ProtectedRoute>
+            <AnimalEdit />
+          </ProtectedRoute>
+        }
+      />
       <Route path="/products" element={<Products />} />
       <Route path="/products/:id" element={<ProductDetail />} />
       <Route

--- a/src/api/animals.api.ts
+++ b/src/api/animals.api.ts
@@ -18,6 +18,7 @@ export const getAnimals = async (params?: AnimalSearchParams): Promise<PageRespo
       ...(params?.region && { region: params.region }),
       ...(params?.city && { city: params.city }),
       ...(params?.keyword && { keyword: params.keyword }),
+      ...(params?.shelterId && { shelterId: params.shelterId }),
     },
   });
   return response.data;
@@ -25,8 +26,28 @@ export const getAnimals = async (params?: AnimalSearchParams): Promise<PageRespo
 
 // 동물 상세 조회
 export const getAnimalById = async (id: number): Promise<Animal> => {
-  const response = await apiClient.get<Animal>(`/api/animals/${id}`);
-  return response.data;
+  const response = await apiClient.get<any>(`/api/animals/${id}`);
+  console.log('getAnimalById 전체 응답:', response);
+  console.log('getAnimalById response.data:', response.data);
+  
+  // 응답 구조 확인: { code, data, message } 형식이거나 직접 Animal 형식일 수 있음
+  const responseData = response.data;
+  
+  // { code, data, message } 형식인 경우
+  if (responseData && typeof responseData === 'object' && 'code' in responseData && 'data' in responseData) {
+    console.log('응답 형식: { code, data, message }');
+    return responseData.data;
+  }
+  
+  // 직접 Animal 객체인 경우
+  if (responseData && typeof responseData === 'object' && 'id' in responseData) {
+    console.log('응답 형식: 직접 Animal 객체');
+    return responseData;
+  }
+  
+  // 예상치 못한 형식
+  console.error('예상치 못한 응답 형식:', responseData);
+  throw new Error('예상치 못한 API 응답 형식입니다.');
 };
 
 // 동물 찜하기
@@ -48,4 +69,117 @@ export const checkFavorite = async (animalId: number): Promise<boolean> => {
     `/api/favorites/${animalId}/check`
   );
   return response.data.data;
+};
+
+// 동물 등록 요청 타입
+// 명세서 기준: careRegNo를 사용 (shelterId 아님)
+export interface CreateAnimalRequest {
+  careRegNo: string; // 필수: 보호소 등록번호 (/api/users/me에서 획득)
+  species: 'DOG' | 'CAT' | 'ETC';
+  status: 'PROTECT' | 'ADOPTION_PENDING' | 'ADOPTED' | 'EUTHANIZED' | 'NATURAL_DEATH' | 'RETURNED' | 'DONATED' | 'RELEASED' | 'ESCAPED' | 'UNKNOWN';
+  noticeStartDate: string; // 필수: 공고 시작일 (YYYY-MM-DD)
+  noticeEndDate: string; // 필수: 공고 종료일 (YYYY-MM-DD)
+  gender: 'MALE' | 'FEMALE' | 'UNKNOWN'; // 필수: 성별
+  neuterStatus: 'YES' | 'NO' | 'UNKNOWN'; // 필수: 중성화 여부 (명세서: YES, NO, UNKNOWN)
+  apmsNoticeNo?: string; // 선택: 공고번호 (미입력 시 자동 생성)
+  apiSource?: 'APMS_ANIMAL' | 'MANUAL'; // 선택: 데이터 출처 (미입력 시 MANUAL)
+  breed?: string;
+  birthYear?: number;
+  weight?: string;
+  color?: string;
+  specialMark?: string;
+  happenDate?: string; // 발견 일자
+  happenPlace?: string; // 발견 장소
+  imageUrl?: string;
+  imageUrl2?: string;
+  description?: string;
+}
+
+// 동물 등록
+export const createAnimal = async (animalData: CreateAnimalRequest): Promise<Animal> => {
+  const response = await apiClient.post<Animal>('/api/animals', animalData);
+  return response.data;
+};
+
+// 동물 수정 요청 타입 (등록과 동일하지만 id는 URL에 포함)
+export type UpdateAnimalRequest = Omit<CreateAnimalRequest, 'careRegNo'> & {
+  careRegNo?: string; // 수정 시에는 선택적
+};
+
+// 동물 수정
+export const updateAnimal = async (id: number, animalData: UpdateAnimalRequest): Promise<Animal> => {
+  const response = await apiClient.put<Animal>(`/api/animals/${id}`, animalData);
+  return response.data;
+};
+
+// 이미지 업로드 응답 타입
+export interface AnimalImageUploadResponse {
+  imageUrl: string;
+}
+
+// 다중 이미지 업로드 응답 타입
+export interface AnimalImagesUploadResponse {
+  imageUrls: string[];
+  count: number;
+}
+
+// 단일 이미지 업로드
+export const uploadAnimalImage = async (file: File): Promise<AnimalImageUploadResponse> => {
+  const formData = new FormData();
+  formData.append('file', file);
+  
+  const response = await apiClient.post<{
+    code?: number;
+    data?: AnimalImageUploadResponse;
+    message?: string;
+    imageUrl?: string; // 직접 응답인 경우
+  }>(
+    '/api/animals/images',
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  );
+  
+  console.log('이미지 업로드 원본 응답:', response.data);
+  
+  // 응답 구조 확인: 래핑되어 있으면 data.imageUrl, 아니면 직접 imageUrl
+  if (response.data.data && response.data.data.imageUrl) {
+    console.log('래핑된 응답에서 imageUrl 추출:', response.data.data.imageUrl);
+    return response.data.data;
+  } else if (response.data.imageUrl) {
+    console.log('직접 응답에서 imageUrl 추출:', response.data.imageUrl);
+    return { imageUrl: response.data.imageUrl };
+  } else {
+    console.error('이미지 업로드 응답 구조:', response.data);
+    throw new Error('이미지 업로드 응답 형식이 올바르지 않습니다. 응답: ' + JSON.stringify(response.data));
+  }
+};
+
+// 다중 이미지 업로드
+export const uploadAnimalImages = async (files: File[]): Promise<AnimalImagesUploadResponse> => {
+  const formData = new FormData();
+  files.forEach((file) => {
+    formData.append('files', file);
+  });
+  
+  const response = await apiClient.post<AnimalImagesUploadResponse>(
+    '/api/animals/images/multiple',
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  );
+  return response.data;
+};
+
+// 이미지 삭제
+export const deleteAnimalImage = async (imageUrl: string): Promise<void> => {
+  await apiClient.delete('/api/animals/images', {
+    params: { imageUrl },
+  });
 };

--- a/src/api/products.api.ts
+++ b/src/api/products.api.ts
@@ -104,8 +104,28 @@ export const getOptionGroups = async (): Promise<OptionGroupResponse[]> => {
 
 // 카테고리 목록 조회
 export const getCategories = async (): Promise<CategoryResponse[]> => {
-  const response = await apiClient.get<CategoryResponse[]>('/api/categories');
-  return response.data;
+  const response = await apiClient.get<{ code: number; data: CategoryResponse[]; message: string } | CategoryResponse[]>('/api/categories');
+  console.log('getCategories 전체 응답:', response);
+  console.log('getCategories response.data:', response.data);
+  
+  // 응답 구조 확인: { code, data, message } 형식이거나 직접 배열 형식일 수 있음
+  const responseData = response.data;
+  
+  // { code, data, message } 형식인 경우
+  if (responseData && typeof responseData === 'object' && 'code' in responseData && 'data' in responseData && Array.isArray(responseData.data)) {
+    console.log('응답 형식: { code, data, message }');
+    return responseData.data;
+  }
+  
+  // 직접 배열인 경우
+  if (Array.isArray(responseData)) {
+    console.log('응답 형식: 직접 배열');
+    return responseData;
+  }
+  
+  // 예상치 못한 형식
+  console.error('예상치 못한 응답 형식:', responseData);
+  throw new Error('예상치 못한 API 응답 형식입니다.');
 };
 
 // 이미지 업로드

--- a/src/api/user.api.ts
+++ b/src/api/user.api.ts
@@ -68,6 +68,10 @@ export const getFavoriteAnimals = async (): Promise<FavoriteListResponse> => {
 };
 
 // 내 보호소가 등록한 동물 목록 조회 (페이징)
+// 명세서 4.2: GET /api/users/me/registered-animals
+// 명세서에는 page, size만 지원 (apiSource 파라미터 없음)
+// 서버가 이미 MANUAL만 반환하는지 확인 필요
+// 만약 서버가 모든 동물을 반환한다면 프론트엔드에서 필터링 필요
 export const getRegisteredAnimals = async (page: number = 0, size: number = 20): Promise<PageResponse<Animal>> => {
   const response = await apiClient.get<{ code: number; data: PageResponse<Animal>; message: string }>('/api/users/me/registered-animals', {
     params: { page, size, sort: 'createdAt,desc' },

--- a/src/components/common/AnimalCardSimple.tsx
+++ b/src/components/common/AnimalCardSimple.tsx
@@ -33,26 +33,41 @@ export default function AnimalCardSimple({ animal }: AnimalCardSimpleProps) {
     }
   };
 
-  const getGenderIcon = () => {
+  const getGenderLabel = () => {
     if (animal.gender === 'MALE') {
-      return { icon: 'male', className: 'text-blue-500', title: '수컷' };
+      return { text: '수컷', className: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400' };
     } else if (animal.gender === 'FEMALE') {
-      return { icon: 'female', className: 'text-pink-500', title: '암컷' };
+      return { text: '암컷', className: 'bg-pink-100 text-pink-800 dark:bg-pink-900/30 dark:text-pink-400' };
+    } else if (!animal.gender || (animal.gender as string) === 'UNKNOWN') {
+      return { text: '미상', className: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400' };
     }
     return null;
   };
 
-  const getNeuterIcon = () => {
-    const neutered = animal.neuterStatus === 'YES' || animal.neutered === true;
-    if (neutered) {
-      return { icon: 'pets', className: 'text-primary', title: '중성화 완료' };
+  const getNeuterLabel = () => {
+    // neuterStatus 우선 확인
+    if (animal.neuterStatus === 'YES') {
+      return { text: '중성화 완료', className: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400' };
+    } else if (animal.neuterStatus === 'NO') {
+      return { text: '중성화 미완료', className: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400' };
+    } else if (animal.neuterStatus === 'UNKNOWN') {
+      return { text: '중성화 미상', className: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400' };
     }
+    
+    // neuterStatus가 없으면 neutered (boolean) 필드 확인
+    if (animal.neutered === true) {
+      return { text: '중성화 완료', className: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400' };
+    } else if (animal.neutered === false) {
+      return { text: '중성화 미완료', className: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400' };
+    }
+    
+    // 둘 다 없으면 null 반환 (배지 표시 안 함)
     return null;
   };
 
   const status = getStatusLabel();
-  const genderIcon = getGenderIcon();
-  const neuterIcon = getNeuterIcon();
+  const gender = getGenderLabel();
+  const neuter = getNeuterLabel();
 
   // 종 + 품종 표시
   const speciesLabel = animal.species === 'DOG' ? '개' : animal.species === 'CAT' ? '고양이' : '기타';
@@ -96,23 +111,26 @@ export default function AnimalCardSimple({ animal }: AnimalCardSimpleProps) {
 
       {/* 정보 */}
       <div className="p-4 flex flex-col flex-grow">
-        {/* 상태 + 아이콘 */}
-        <div className="flex justify-between items-start mb-2">
+        {/* 상태 + 성별 + 중성화 배지 */}
+        <div className="flex items-center gap-2 mb-2 flex-wrap">
+          {/* 상태 배지 */}
           <span className={`text-xs font-bold rounded-full px-3 py-1 ${status.className}`}>
             {status.text}
           </span>
-          <div className="flex gap-2 text-gray-500 dark:text-gray-400">
-            {genderIcon && (
-              <span className={`material-symbols-outlined ${genderIcon.className}`} title={genderIcon.title}>
-                {genderIcon.icon}
-              </span>
-            )}
-            {neuterIcon && (
-              <span className={`material-symbols-outlined ${neuterIcon.className}`} title={neuterIcon.title}>
-                {neuterIcon.icon}
-              </span>
-            )}
-          </div>
+          
+          {/* 성별 배지 */}
+          {gender && (
+            <span className={`text-xs font-bold rounded-full px-3 py-1 ${gender.className}`}>
+              {gender.text}
+            </span>
+          )}
+          
+          {/* 중성화 배지 */}
+          {neuter && (
+            <span className={`text-xs font-bold rounded-full px-3 py-1 ${neuter.className}`}>
+              {neuter.text}
+            </span>
+          )}
         </div>
 
         {/* 제목 */}

--- a/src/components/common/ProductFilterSidebar.tsx
+++ b/src/components/common/ProductFilterSidebar.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
-import type { ProductSearchParams } from '../../types/api.types';
+import { useQuery } from '@tanstack/react-query';
+import { getCategories } from '../../api/products.api';
+import type { ProductSearchParams, CategoryResponse } from '../../types/api.types';
 
 interface ProductFilterSidebarProps {
   filters: ProductSearchParams;
@@ -7,20 +9,35 @@ interface ProductFilterSidebarProps {
   onReset: () => void;
 }
 
-// 카테고리 정의 (디자인 HTML 아이콘과 일치)
-const categories = [
-  { id: 1, name: '사료 및 간식', icon: 'skeleton' },
-  { id: 2, name: '장난감', icon: 'stadia_controller' },
-  { id: 3, name: '위생/미용 용품', icon: 'spark' },
-  { id: 4, name: '의류/액세서리', icon: 'checkroom' },
-  { id: 5, name: '굿즈', icon: 'storefront' },
-];
+// 카테고리 아이콘 매핑 (카테고리 이름 기반)
+const getCategoryIcon = (categoryName: string): string => {
+  const iconMap: Record<string, string> = {
+    '사료 및 간식': 'skeleton',
+    '장난감': 'stadia_controller',
+    '위생/미용 용품': 'spark',
+    '의류/액세서리': 'checkroom',
+    '굿즈': 'storefront',
+  };
+  return iconMap[categoryName] || 'category';
+};
 
 export default function ProductFilterSidebar({
   filters,
   onFilterChange,
   onReset,
 }: ProductFilterSidebarProps) {
+  // 카테고리 목록 조회
+  const { data: allCategories = [], isLoading: isLoadingCategories } = useQuery<CategoryResponse[]>({
+    queryKey: ['categories'],
+    queryFn: getCategories,
+  });
+
+  // 최상위 카테고리만 필터링 (parentId가 null인 것만)
+  // 최대 10개까지만 표시 (너무 많으면 사이드바가 길어짐)
+  const topLevelCategories = allCategories
+    .filter(category => category.parentId === null)
+    .slice(0, 10);
+
   // 로컬 상태 (입력 중인 값 저장 - 엔터/버튼 클릭 전까지 검색 안 함)
   const [localKeyword, setLocalKeyword] = useState(filters.keyword || '');
   const [localMinPrice, setLocalMinPrice] = useState<string>(filters.minPrice?.toString() || '');
@@ -116,22 +133,35 @@ export default function ProductFilterSidebar({
               </p>
             </button>
             
-            {categories.map((category) => (
-              <button
-                key={category.id}
-                onClick={() => handleCategoryClick(category.id)}
-                className={`flex items-center gap-3 px-3 py-2 rounded-lg text-left ${
-                  filters.categoryId === category.id
-                    ? 'bg-primary/20 text-primary'
-                    : 'hover:bg-secondary-light dark:hover:bg-secondary-dark'
-                }`}
-              >
-                <span className="material-symbols-outlined">{category.icon}</span>
-                <p className={`text-sm ${filters.categoryId === category.id ? 'font-bold' : 'font-medium'}`}>
-                  {category.name}
-                </p>
-              </button>
-            ))}
+            {isLoadingCategories ? (
+              <div className="px-3 py-2 text-sm text-gray-500">카테고리 불러오는 중...</div>
+            ) : topLevelCategories.length === 0 ? (
+              <div className="px-3 py-2 text-sm text-gray-500">등록된 카테고리가 없습니다</div>
+            ) : (
+              <>
+                {topLevelCategories.map((category) => (
+                  <button
+                    key={category.id}
+                    onClick={() => handleCategoryClick(category.id)}
+                    className={`flex items-center gap-3 px-3 py-2 rounded-lg text-left ${
+                      filters.categoryId === category.id
+                        ? 'bg-primary/20 text-primary'
+                        : 'hover:bg-secondary-light dark:hover:bg-secondary-dark'
+                    }`}
+                  >
+                    <span className="material-symbols-outlined">{getCategoryIcon(category.name)}</span>
+                    <p className={`text-sm ${filters.categoryId === category.id ? 'font-bold' : 'font-medium'}`}>
+                      {category.name}
+                    </p>
+                  </button>
+                ))}
+                {topLevelCategories.length >= 10 && allCategories.filter(c => c.parentId === null).length > 10 && (
+                  <div className="px-3 py-2 text-xs text-gray-400 italic">
+                    (최상위 카테고리 {allCategories.filter(c => c.parentId === null).length}개 중 10개 표시)
+                  </div>
+                )}
+              </>
+            )}
           </div>
         </div>
 

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+interface ToastProps {
+  message: string;
+  type?: 'success' | 'error' | 'info';
+  isVisible: boolean;
+  onClose: () => void;
+  duration?: number;
+}
+
+export default function Toast({ message, type = 'info', isVisible, onClose, duration = 3000 }: ToastProps) {
+  useEffect(() => {
+    if (isVisible && duration > 0) {
+      const timer = setTimeout(() => {
+        onClose();
+      }, duration);
+      return () => clearTimeout(timer);
+    }
+  }, [isVisible, duration, onClose]);
+
+  if (!isVisible) return null;
+
+  const typeStyles = {
+    success: 'bg-emerald-500 dark:bg-emerald-600 text-white',
+    error: 'bg-red-500 dark:bg-red-600 text-white',
+    info: 'bg-blue-500 dark:bg-blue-600 text-white',
+  };
+
+  const iconMap = {
+    success: 'check_circle',
+    error: 'error',
+    info: 'info',
+  };
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 animate-fade-in">
+      <div className={`${typeStyles[type]} flex items-center gap-3 px-4 py-3 rounded-lg shadow-xl shadow-gray-900/20`}>
+        <span className="material-symbols-outlined text-xl">{iconMap[type]}</span>
+        <span className="text-sm font-medium">{message}</span>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from '../../store/authStore';
 
@@ -6,8 +6,6 @@ export default function AdminSidebar() {
   const navigate = useNavigate();
   const location = useLocation();
   const { logout } = useAuthStore();
-  const [isProductMenuOpen, setIsProductMenuOpen] = useState(false);
-  const [isOptionMenuOpen, setIsOptionMenuOpen] = useState(false);
 
   const handleLogout = () => {
     logout();
@@ -15,10 +13,24 @@ export default function AdminSidebar() {
   };
 
   const isActive = (path: string) => location.pathname === path;
+  
+  // 상품관리 드롭다운이 열려있어야 하는 경우
+  const shouldProductMenuBeOpen = isActive('/admin/products') || isActive('/products/new') || isActive('/admin/products/:productId/edit');
+  const shouldOptionMenuBeOpen = isActive('/admin/option-groups');
+  
+  // 초기 상태 설정
+  const [isProductMenuOpen, setIsProductMenuOpen] = useState(shouldProductMenuBeOpen);
+  const [isOptionMenuOpen, setIsOptionMenuOpen] = useState(shouldOptionMenuBeOpen);
+  
+  // 경로 변경 시 드롭다운 상태 업데이트
+  useEffect(() => {
+    setIsProductMenuOpen(shouldProductMenuBeOpen);
+    setIsOptionMenuOpen(shouldOptionMenuBeOpen);
+  }, [location.pathname]);
 
   return (
     <aside className="w-64 h-full flex flex-col bg-surface-light dark:bg-surface-dark border-r border-[#e5e7eb] dark:border-gray-700 flex-shrink-0 z-20">
-      <div className="p-6 flex items-center gap-3">
+      <Link to="/" className="p-6 flex items-center gap-3 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer">
         <div className="size-10 rounded-full bg-primary flex items-center justify-center text-text-main">
           <span className="material-symbols-outlined text-[24px]">pets</span>
         </div>
@@ -26,7 +38,7 @@ export default function AdminSidebar() {
           <h1 className="text-text-main dark:text-white text-lg font-bold leading-tight">PawBridge</h1>
           <p className="text-text-secondary text-xs font-medium">관리자 콘솔</p>
         </div>
-      </div>
+      </Link>
       <nav className="flex-1 px-4 flex flex-col gap-1 overflow-y-auto">
         <Link
           to="/admin/dashboard"
@@ -131,13 +143,24 @@ export default function AdminSidebar() {
         <div className="mt-2">
           <button
             onClick={() => setIsProductMenuOpen(!isProductMenuOpen)}
-            className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary cursor-pointer transition-colors group"
+            className={`w-full flex items-center justify-between px-3 py-2.5 rounded-lg transition-colors group ${
+              shouldProductMenuBeOpen
+                ? 'bg-primary/20 text-text-main dark:text-white'
+                : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary'
+            }`}
           >
             <div className="flex items-center gap-3">
-              <span className="material-symbols-outlined group-hover:text-text-main dark:group-hover:text-white transition-colors">
+              <span
+                className={`material-symbols-outlined ${
+                  shouldProductMenuBeOpen ? 'text-text-main dark:text-white' : 'group-hover:text-text-main dark:group-hover:text-white transition-colors'
+                }`}
+                style={{ fontVariationSettings: shouldProductMenuBeOpen ? "'FILL' 1" : "'FILL' 0" }}
+              >
                 inventory_2
               </span>
-              <span className="text-sm font-medium group-hover:text-text-main dark:group-hover:text-white transition-colors">상품 관리</span>
+              <span className={`text-sm ${shouldProductMenuBeOpen ? 'font-semibold' : 'font-medium group-hover:text-text-main dark:group-hover:text-white transition-colors'}`}>
+                상품 관리
+              </span>
             </div>
             <span className={`material-symbols-outlined text-sm transition-transform ${isProductMenuOpen ? 'rotate-180' : ''}`}>
               expand_more
@@ -147,15 +170,21 @@ export default function AdminSidebar() {
             <div className="flex flex-col mt-1 gap-1">
               <Link
                 to="/admin/products"
-                className="pl-11 flex items-center gap-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary hover:text-text-main dark:hover:text-white transition-colors text-sm"
-                onClick={() => setIsProductMenuOpen(false)}
+                className={`pl-11 flex items-center gap-3 py-2 rounded-lg transition-colors text-sm ${
+                  isActive('/admin/products')
+                    ? 'bg-primary/10 text-primary dark:text-primary font-bold'
+                    : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary hover:text-text-main dark:hover:text-white'
+                }`}
               >
                 상품 목록
               </Link>
               <Link
                 to="/products/new"
-                className="pl-11 flex items-center gap-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary hover:text-text-main dark:hover:text-white transition-colors text-sm"
-                onClick={() => setIsProductMenuOpen(false)}
+                className={`pl-11 flex items-center gap-3 py-2 rounded-lg transition-colors text-sm ${
+                  isActive('/products/new')
+                    ? 'bg-primary/10 text-primary dark:text-primary font-bold'
+                    : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary hover:text-text-main dark:hover:text-white'
+                }`}
               >
                 상품 등록
               </Link>
@@ -165,13 +194,24 @@ export default function AdminSidebar() {
         <div className="mt-2 mb-4">
           <button
             onClick={() => setIsOptionMenuOpen(!isOptionMenuOpen)}
-            className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary cursor-pointer transition-colors group"
+            className={`w-full flex items-center justify-between px-3 py-2.5 rounded-lg transition-colors group ${
+              shouldOptionMenuBeOpen
+                ? 'bg-primary/20 text-text-main dark:text-white'
+                : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary'
+            }`}
           >
             <div className="flex items-center gap-3">
-              <span className="material-symbols-outlined group-hover:text-text-main dark:group-hover:text-white transition-colors">
+              <span
+                className={`material-symbols-outlined ${
+                  shouldOptionMenuBeOpen ? 'text-text-main dark:text-white' : 'group-hover:text-text-main dark:group-hover:text-white transition-colors'
+                }`}
+                style={{ fontVariationSettings: shouldOptionMenuBeOpen ? "'FILL' 1" : "'FILL' 0" }}
+              >
                 tune
               </span>
-              <span className="text-sm font-medium group-hover:text-text-main dark:group-hover:text-white transition-colors">옵션 관리</span>
+              <span className={`text-sm ${shouldOptionMenuBeOpen ? 'font-semibold' : 'font-medium group-hover:text-text-main dark:group-hover:text-white transition-colors'}`}>
+                옵션 관리
+              </span>
             </div>
             <span className={`material-symbols-outlined text-sm transition-transform ${isOptionMenuOpen ? 'rotate-180' : ''}`}>
               expand_more
@@ -181,7 +221,11 @@ export default function AdminSidebar() {
             <div className="flex flex-col mt-1 gap-1">
               <Link
                 to="/admin/option-groups"
-                className="pl-11 flex items-center gap-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary hover:text-text-main dark:hover:text-white transition-colors text-sm"
+                className={`pl-11 flex items-center gap-3 py-2 rounded-lg transition-colors text-sm ${
+                  isActive('/admin/option-groups')
+                    ? 'bg-primary/10 text-primary dark:text-primary font-bold'
+                    : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-text-secondary hover:text-text-main dark:hover:text-white'
+                }`}
               >
                 옵션 그룹 관리
               </Link>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -27,11 +27,6 @@ export default function Footer() {
                   동물 검색
                 </Link>
               </li>
-              <li>
-                <Link to="/shelters" className="hover:text-primary transition-colors">
-                  보호소 찾기
-                </Link>
-              </li>
             </ul>
           </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,17 @@
       transform: translateY(0);
     }
   }
+
+  @keyframes slideUp {
+    from {
+      transform: translateY(20px);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
 }
 
 /* 스크롤바 스타일링 */

--- a/src/pages/AdminCategoryManagement.tsx
+++ b/src/pages/AdminCategoryManagement.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getCategories, createCategory, updateCategory, deleteCategory } from '../api/products.api';
 import type { CategoryResponse, CreateCategoryRequest, UpdateCategoryRequest } from '../types/api.types';
 import { useAuthStore } from '../store/authStore';
 import CustomSelect from '../components/common/CustomSelect';
+import AdminSidebar from '../components/layout/AdminSidebar';
 
 interface CategoryTreeNodeProps {
   category: CategoryResponse;
@@ -313,132 +313,49 @@ export default function AdminCategoryManagement() {
   ];
 
   return (
-    <div className="bg-background-light dark:bg-background-dark text-text-main font-sans min-h-screen flex overflow-hidden">
+    <div className="bg-background-light dark:bg-background-dark text-text-main dark:text-white h-screen overflow-hidden flex">
       {/* 사이드바 */}
-      <aside className="w-64 flex-shrink-0 bg-surface-light dark:bg-surface-dark border-r border-[#dbe6e3] dark:border-[#2a3c38] flex flex-col h-screen z-20">
-        <div className="h-16 flex items-center px-6 border-b border-[#f0f5f3] dark:border-[#2a3c38]">
-          <div className="flex items-center gap-3">
-            <div className="size-8 text-primary flex items-center justify-center bg-background-dark rounded-lg">
-              <span className="material-symbols-outlined text-[24px]">pets</span>
-            </div>
-            <h1 className="text-text-main dark:text-white text-lg font-extrabold tracking-tight">PawBridge</h1>
-          </div>
-        </div>
-        <nav className="flex-1 overflow-y-auto py-6 px-4 flex flex-col gap-1 no-scrollbar">
-          <Link
-            to="/admin/dashboard"
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors group"
-          >
-            <span className="material-symbols-outlined text-[20px]">dashboard</span>
-            <span className="text-sm font-medium">대시보드</span>
-          </Link>
-          <button className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors group">
-            <span className="material-symbols-outlined text-[20px]">bar_chart</span>
-            <span className="text-sm font-medium">통계</span>
-          </button>
-          <div className="my-2 border-t border-[#f0f5f3] dark:border-[#2a3c38]"></div>
-          <div className="px-3 pb-2 pt-1 text-xs font-bold text-text-sub/70 dark:text-gray-500 uppercase tracking-wider">
-            운영 관리
-          </div>
-          <button className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors group">
-            <span className="material-symbols-outlined text-[20px]">group</span>
-            <span className="text-sm font-medium">회원 관리</span>
-          </button>
-          <button className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors group">
-            <span className="material-symbols-outlined text-[20px]">article</span>
-            <span className="text-sm font-medium">게시글 관리</span>
-          </button>
-          <Link
-            to="/admin/categories"
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg bg-primary/10 text-teal-900 dark:text-primary font-bold transition-colors"
-          >
-            <span className="material-symbols-outlined text-[20px] text-primary dark:text-primary">category</span>
-            <span className="text-sm">카테고리 관리</span>
-          </Link>
-          <div className="my-2 border-t border-[#f0f5f3] dark:border-[#2a3c38]"></div>
-          <div className="px-3 pb-2 pt-1 text-xs font-bold text-text-sub/70 dark:text-gray-500 uppercase tracking-wider">
-            쇼핑몰 관리
-          </div>
-          <details className="group">
-            <summary className="flex cursor-pointer items-center justify-between gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors select-none">
-              <div className="flex items-center gap-3">
-                <span className="material-symbols-outlined text-[20px]">shopping_bag</span>
-                <span className="text-sm font-medium">상품 관리</span>
-              </div>
-              <span className="material-symbols-outlined text-[18px] group-open:rotate-180 transition-transform">
-                expand_more
-              </span>
-            </summary>
-            <div className="pl-10 pr-2 pb-1 mt-1 flex flex-col gap-1">
-              <button className="block px-3 py-2 rounded-lg text-sm text-text-sub dark:text-gray-400 hover:text-primary dark:hover:text-primary hover:bg-background-light dark:hover:bg-background-dark/30 transition-colors text-left">
-                상품 목록
-              </button>
-              <Link
-                to="/products/new"
-                className="block px-3 py-2 rounded-lg text-sm text-text-sub dark:text-gray-400 hover:text-primary dark:hover:text-primary hover:bg-background-light dark:hover:bg-background-dark/30 transition-colors"
-              >
-                상품 등록
-              </Link>
-            </div>
-          </details>
-          <details className="group">
-            <summary className="flex cursor-pointer items-center justify-between gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors select-none">
-              <div className="flex items-center gap-3">
-                <span className="material-symbols-outlined text-[20px]">tune</span>
-                <span className="text-sm font-medium">옵션 관리</span>
-              </div>
-              <span className="material-symbols-outlined text-[18px] group-open:rotate-180 transition-transform">
-                expand_more
-              </span>
-            </summary>
-            <div className="pl-10 pr-2 pb-1 mt-1 flex flex-col gap-1">
-              <button className="block px-3 py-2 rounded-lg text-sm text-text-sub dark:text-gray-400 hover:text-primary dark:hover:text-primary hover:bg-background-light dark:hover:bg-background-dark/30 transition-colors text-left">
-                옵션 그룹 관리
-              </button>
-              <button className="block px-3 py-2 rounded-lg text-sm text-text-sub dark:text-gray-400 hover:text-primary dark:hover:text-primary hover:bg-background-light dark:hover:bg-background-dark/30 transition-colors text-left">
-                옵션 값 관리
-              </button>
-            </div>
-          </details>
-        </nav>
-        <div className="p-4 border-t border-[#f0f5f3] dark:border-[#2a3c38]">
-          <div className="flex items-center gap-3 p-2 rounded-lg hover:bg-background-light dark:hover:bg-background-dark/50 cursor-pointer transition-colors">
-            <div
-              className="bg-center bg-no-repeat bg-cover rounded-full size-9 border border-primary/50 bg-primary/20 flex items-center justify-center"
-            >
-              <div className="w-full h-full flex items-center justify-center text-primary font-bold text-xs">
-                {user?.name?.charAt(0) || '관'}
-              </div>
-            </div>
-            <div className="flex flex-col overflow-hidden">
-              <span className="text-sm font-bold text-text-main dark:text-white truncate">{user?.name || '관리자'}</span>
-              <span className="text-xs text-text-sub dark:text-gray-400 truncate">{user?.email || 'admin@pawbridge.com'}</span>
-            </div>
-          </div>
-        </div>
-      </aside>
+      <AdminSidebar />
 
       {/* 메인 콘텐츠 */}
-      <div className="flex-1 flex flex-col h-screen overflow-hidden relative">
+      <main className="flex-1 flex flex-col min-w-0 h-full overflow-hidden bg-background-light dark:bg-background-dark relative">
         {/* 헤더 */}
-        <header className="h-16 bg-surface-light dark:bg-surface-dark border-b border-[#f0f5f3] dark:border-[#2a3c38] flex items-center justify-between px-6 lg:px-10 sticky top-0 z-10">
-          <div className="flex items-center gap-2 text-sm text-text-sub dark:text-gray-400">
-            <span className="material-symbols-outlined text-[18px]">home</span>
-            <span>/</span>
-            <span>카테고리 관리</span>
-          </div>
+        <header className="flex-none h-16 bg-surface-light dark:bg-surface-dark border-b border-[#e5e7eb] dark:border-gray-700 px-8 flex items-center justify-between z-10">
           <div className="flex items-center gap-4">
-            <button className="p-2 text-text-sub dark:text-gray-400 hover:text-primary transition-colors">
-              <span className="material-symbols-outlined">notifications</span>
-            </button>
-            <button className="p-2 text-text-sub dark:text-gray-400 hover:text-primary transition-colors">
-              <span className="material-symbols-outlined">settings</span>
-            </button>
+            <h2 className="text-xl font-bold text-text-main dark:text-white">카테고리 관리</h2>
+          </div>
+          <div className="flex items-center gap-6">
+            <div className="hidden md:flex items-center w-64 h-10 rounded-lg bg-background-light dark:bg-gray-800 px-3 border border-transparent focus-within:border-primary transition-colors">
+              <span className="material-symbols-outlined text-text-secondary">search</span>
+              <input
+                className="bg-transparent border-none outline-none text-sm ml-2 w-full text-text-main dark:text-white placeholder:text-text-secondary focus:ring-0"
+                placeholder="검색..."
+                type="text"
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <button className="size-10 rounded-full flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 text-text-main dark:text-white transition-colors relative">
+                <span className="material-symbols-outlined">notifications</span>
+                <span className="absolute top-2 right-2 size-2 bg-red-500 rounded-full border border-white dark:border-gray-800"></span>
+              </button>
+              <button className="flex items-center gap-2 pl-1 pr-3 py-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                <div
+                  className="size-8 rounded-full bg-cover bg-center border border-gray-200 bg-primary/20 flex items-center justify-center"
+                >
+                  <div className="w-full h-full flex items-center justify-center text-text-main font-bold text-xs">
+                    {user?.name?.charAt(0) || '관'}
+                  </div>
+                </div>
+                <span className="text-sm font-semibold text-text-main dark:text-white hidden lg:block">
+                  {user?.name || '관리자'}님
+                </span>
+              </button>
+            </div>
           </div>
         </header>
 
         {/* 메인 콘텐츠 영역 */}
-        <main className="flex-1 overflow-y-auto p-4 lg:p-10 bg-background-light dark:bg-background-dark">
+        <div className="flex-1 overflow-y-auto p-8 bg-background-light dark:bg-background-dark">
           <div className="max-w-[1280px] mx-auto">
             <div className="mb-8">
               <h1 className="text-2xl md:text-3xl font-bold text-text-main dark:text-white mb-2">카테고리 관리</h1>
@@ -619,8 +536,8 @@ export default function AdminCategoryManagement() {
               </section>
             </div>
           </div>
-        </main>
-      </div>
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/pages/AdminOptionGroupManagement.tsx
+++ b/src/pages/AdminOptionGroupManagement.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getOptionGroups,
@@ -18,6 +17,7 @@ import type {
   UpdateOptionValueRequest,
 } from '../types/api.types';
 import { useAuthStore } from '../store/authStore';
+import AdminSidebar from '../components/layout/AdminSidebar';
 
 export default function AdminOptionGroupManagement() {
   const { user } = useAuthStore();
@@ -276,112 +276,49 @@ export default function AdminOptionGroupManagement() {
   );
 
   return (
-    <div className="bg-background-light dark:bg-background-dark text-text-main font-sans min-h-screen flex overflow-hidden">
+    <div className="bg-background-light dark:bg-background-dark text-text-main dark:text-white h-screen overflow-hidden flex">
       {/* 사이드바 */}
-      <aside className="w-64 flex-shrink-0 bg-surface-light dark:bg-surface-dark border-r border-[#dbe6e3] dark:border-[#2a3c38] flex flex-col h-screen z-20">
-        <div className="h-16 flex items-center px-6 border-b border-[#f0f5f3] dark:border-[#2a3c38]">
-          <div className="flex items-center gap-3">
-            <div className="size-8 text-primary flex items-center justify-center bg-background-dark rounded-lg">
-              <span className="material-symbols-outlined text-[24px]">pets</span>
-            </div>
-            <h1 className="text-text-main dark:text-white text-lg font-extrabold tracking-tight">PawBridge</h1>
-          </div>
-        </div>
-        <nav className="flex-1 overflow-y-auto py-6 px-4 flex flex-col gap-1 no-scrollbar">
-          <Link
-            to="/admin/dashboard"
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors group"
-          >
-            <span className="material-symbols-outlined text-[20px]">dashboard</span>
-            <span className="text-sm font-medium">대시보드</span>
-          </Link>
-          <button className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors group">
-            <span className="material-symbols-outlined text-[20px]">bar_chart</span>
-            <span className="text-sm font-medium">통계</span>
-          </button>
-          <div className="my-2 border-t border-[#f0f5f3] dark:border-[#2a3c38]"></div>
-          <div className="px-3 pb-2 pt-1 text-xs font-bold text-text-sub/70 dark:text-gray-500 uppercase tracking-wider">
-            운영 관리
-          </div>
-          <button className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors group">
-            <span className="material-symbols-outlined text-[20px]">group</span>
-            <span className="text-sm font-medium">회원 관리</span>
-          </button>
-          <button className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors group">
-            <span className="material-symbols-outlined text-[20px]">article</span>
-            <span className="text-sm font-medium">게시글 관리</span>
-          </button>
-          <Link
-            to="/admin/categories"
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors group"
-          >
-            <span className="material-symbols-outlined text-[20px]">category</span>
-            <span className="text-sm font-medium">카테고리 관리</span>
-          </Link>
-          <div className="my-2 border-t border-[#f0f5f3] dark:border-[#2a3c38]"></div>
-          <div className="px-3 pb-2 pt-1 text-xs font-bold text-text-sub/70 dark:text-gray-500 uppercase tracking-wider">
-            쇼핑몰 관리
-          </div>
-          <div className="flex flex-col gap-1">
-            <button className="flex items-center justify-between px-3 py-2.5 rounded-lg text-text-sub dark:text-gray-400 hover:bg-background-light dark:hover:bg-background-dark/50 hover:text-text-main dark:hover:text-white transition-colors group">
-              <div className="flex items-center gap-3">
-                <span className="material-symbols-outlined text-[20px]">inventory_2</span>
-                <span className="text-sm font-medium">상품 관리</span>
-              </div>
-              <span className="material-symbols-outlined text-[18px]">expand_more</span>
-            </button>
-          </div>
-          <div className="my-2 border-t border-[#f0f5f3] dark:border-[#2a3c38]"></div>
-          <div className="px-3 pb-2 pt-1 text-xs font-bold text-text-sub/70 dark:text-gray-500 uppercase tracking-wider">
-            설정
-          </div>
-          <div className="flex flex-col gap-1">
-            <button className="flex items-center justify-between px-3 py-2.5 rounded-lg text-primary bg-primary/10 transition-colors">
-              <div className="flex items-center gap-3">
-                <span className="material-symbols-outlined text-[20px]">tune</span>
-                <span className="text-sm font-bold">옵션 관리</span>
-              </div>
-              <span className="material-symbols-outlined text-[18px]">expand_less</span>
-            </button>
-            <div className="pl-10 flex flex-col gap-1 mt-1">
-              <Link
-                to="/admin/option-groups"
-                className="block px-3 py-2 rounded-lg text-sm font-bold text-primary relative before:absolute before:left-[-14px] before:top-1/2 before:-translate-y-1/2 before:w-1 before:h-1 before:rounded-full before:bg-primary"
-              >
-                옵션 그룹 관리
-              </Link>
-            </div>
-          </div>
-        </nav>
-        <div className="p-4 border-t border-[#f0f5f3] dark:border-[#2a3c38]">
-          <div className="flex items-center gap-3 p-2 rounded-lg hover:bg-background-light dark:hover:bg-background-dark/50 cursor-pointer transition-colors">
-            <div className="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-9 border border-primary/50"></div>
-            <div className="flex flex-col overflow-hidden">
-              <span className="text-sm font-bold text-text-main dark:text-white truncate">관리자</span>
-              <span className="text-xs text-text-sub dark:text-gray-400 truncate">{user?.email || 'admin@pawbridge.com'}</span>
-            </div>
-          </div>
-        </div>
-      </aside>
+      <AdminSidebar />
 
-      <div className="flex-1 flex flex-col h-screen overflow-hidden relative">
+      {/* 메인 콘텐츠 */}
+      <main className="flex-1 flex flex-col min-w-0 h-full overflow-hidden bg-background-light dark:bg-background-dark relative">
         {/* 헤더 */}
-        <header className="h-16 flex items-center justify-between px-6 bg-surface-light dark:bg-surface-dark border-b border-[#f0f5f3] dark:border-[#2a3c38] flex-shrink-0 z-10">
-          <nav className="hidden lg:flex items-center gap-2 text-sm text-text-sub">
-            <span className="hover:text-primary cursor-pointer transition-colors">옵션 관리</span>
-            <span className="material-symbols-outlined text-xs">chevron_right</span>
-            <span className="font-bold text-primary">옵션 그룹 관리</span>
-          </nav>
-          <div className="flex items-center gap-4 ml-auto">
-            <button className="p-2 text-text-sub dark:text-gray-400 hover:text-primary transition-colors relative">
-              <span className="absolute top-2 right-2.5 w-2 h-2 bg-red-500 rounded-full border-2 border-white dark:border-surface-dark"></span>
-              <span className="material-symbols-outlined">notifications</span>
-            </button>
+        <header className="flex-none h-16 bg-surface-light dark:bg-surface-dark border-b border-[#e5e7eb] dark:border-gray-700 px-8 flex items-center justify-between z-10">
+          <div className="flex items-center gap-4">
+            <h2 className="text-xl font-bold text-text-main dark:text-white">옵션 그룹 관리</h2>
+          </div>
+          <div className="flex items-center gap-6">
+            <div className="hidden md:flex items-center w-64 h-10 rounded-lg bg-background-light dark:bg-gray-800 px-3 border border-transparent focus-within:border-primary transition-colors">
+              <span className="material-symbols-outlined text-text-secondary">search</span>
+              <input
+                className="bg-transparent border-none outline-none text-sm ml-2 w-full text-text-main dark:text-white placeholder:text-text-secondary focus:ring-0"
+                placeholder="검색..."
+                type="text"
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <button className="size-10 rounded-full flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 text-text-main dark:text-white transition-colors relative">
+                <span className="material-symbols-outlined">notifications</span>
+                <span className="absolute top-2 right-2 size-2 bg-red-500 rounded-full border border-white dark:border-gray-800"></span>
+              </button>
+              <button className="flex items-center gap-2 pl-1 pr-3 py-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                <div
+                  className="size-8 rounded-full bg-cover bg-center border border-gray-200 bg-primary/20 flex items-center justify-center"
+                >
+                  <div className="w-full h-full flex items-center justify-center text-text-main font-bold text-xs">
+                    {user?.name?.charAt(0) || '관'}
+                  </div>
+                </div>
+                <span className="text-sm font-semibold text-text-main dark:text-white hidden lg:block">
+                  {user?.name || '관리자'}님
+                </span>
+              </button>
+            </div>
           </div>
         </header>
 
-        {/* 메인 콘텐츠 영역 */}
-        <main className="flex-1 overflow-y-auto p-4 lg:p-6 bg-background-light dark:bg-background-dark">
+        {/* 콘텐츠 영역 */}
+        <div className="flex-1 overflow-y-auto p-8 bg-background-light dark:bg-background-dark">
           <div className="max-w-[1280px] mx-auto">
             <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 mb-6">
               <div>
@@ -698,8 +635,8 @@ export default function AdminOptionGroupManagement() {
               </section>
             </div>
           </div>
-        </main>
-      </div>
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/pages/AdminPostManagement.tsx
+++ b/src/pages/AdminPostManagement.tsx
@@ -191,40 +191,43 @@ export default function AdminPostManagement() {
     <div className="bg-background-light dark:bg-background-dark text-text-main dark:text-white h-screen overflow-hidden flex">
       <AdminSidebar />
 
-      <main className="flex-1 flex flex-col h-full overflow-hidden bg-background-light dark:bg-background-dark relative">
+      <main className="flex-1 flex flex-col min-w-0 h-full overflow-hidden bg-background-light dark:bg-background-dark relative">
         {/* 헤더 */}
-        <header className="h-16 flex items-center justify-between px-8 bg-surface-light dark:bg-surface-dark border-b border-[#e5e7eb] dark:border-gray-700 shrink-0 z-10">
-          <div className="flex-1 max-w-md relative group">
-            <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
-              <span className="material-symbols-outlined text-text-sub dark:text-gray-400 group-focus-within:text-primary transition-colors">
-                search
-              </span>
-            </div>
-            <input
-              type="text"
-              value={searchKeyword}
-              onChange={(e) => {
-                setSearchKeyword(e.target.value);
-                setCurrentPage(0); // 검색 시 첫 페이지로 이동
-              }}
-              className="w-full pl-11 pr-4 py-2.5 bg-background-light dark:bg-background-dark border border-transparent hover:border-[#dbe6e3] dark:hover:border-gray-700 focus:bg-white dark:focus:bg-gray-800 focus:border-primary rounded-xl text-text-main dark:text-white placeholder-text-sub dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all text-sm"
-              placeholder="검색어를 입력하세요..."
-            />
-          </div>
+        <header className="flex-none h-16 bg-surface-light dark:bg-surface-dark border-b border-[#e5e7eb] dark:border-gray-700 px-8 flex items-center justify-between z-10">
           <div className="flex items-center gap-4">
-            <button className="p-2 text-text-sub dark:text-gray-400 hover:text-text-main hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors relative">
-              <span className="material-symbols-outlined">notifications</span>
-              <span className="absolute top-2.5 right-2.5 w-2 h-2 bg-red-500 rounded-full ring-2 ring-white dark:ring-gray-800"></span>
-            </button>
-            <div className="w-px h-8 bg-gray-200 dark:bg-gray-700"></div>
+            <h2 className="text-xl font-bold text-text-main dark:text-white">게시글 관리</h2>
+          </div>
+          <div className="flex items-center gap-6">
+            <div className="hidden md:flex items-center w-64 h-10 rounded-lg bg-background-light dark:bg-gray-800 px-3 border border-transparent focus-within:border-primary transition-colors">
+              <span className="material-symbols-outlined text-text-secondary">search</span>
+              <input
+                type="text"
+                value={searchKeyword}
+                onChange={(e) => {
+                  setSearchKeyword(e.target.value);
+                  setCurrentPage(0);
+                }}
+                placeholder="검색어를 입력하세요..."
+                className="bg-transparent border-none outline-none text-sm ml-2 w-full text-text-main dark:text-white placeholder:text-text-secondary focus:ring-0"
+              />
+            </div>
             <div className="flex items-center gap-3">
-              <div className="text-right hidden sm:block">
-                <p className="text-sm font-bold text-text-main dark:text-white">{user?.name || '관리자'}</p>
-                <p className="text-xs text-text-sub dark:text-gray-400">Super Admin</p>
-              </div>
-              <div className="h-9 w-9 rounded-full bg-primary/20 flex items-center justify-center border border-primary/30">
-                <span className="material-symbols-outlined text-primary text-[20px]">person</span>
-              </div>
+              <button className="size-10 rounded-full flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 text-text-main dark:text-white transition-colors relative">
+                <span className="material-symbols-outlined">notifications</span>
+                <span className="absolute top-2 right-2 size-2 bg-red-500 rounded-full border border-white dark:border-gray-800"></span>
+              </button>
+              <button className="flex items-center gap-2 pl-1 pr-3 py-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                <div
+                  className="size-8 rounded-full bg-cover bg-center border border-gray-200 bg-primary/20 flex items-center justify-center"
+                >
+                  <div className="w-full h-full flex items-center justify-center text-text-main font-bold text-xs">
+                    {user?.name?.charAt(0) || '관'}
+                  </div>
+                </div>
+                <span className="text-sm font-semibold text-text-main dark:text-white hidden lg:block">
+                  {user?.name || '관리자'}님
+                </span>
+              </button>
             </div>
           </div>
         </header>

--- a/src/pages/AdminProductList.tsx
+++ b/src/pages/AdminProductList.tsx
@@ -1,13 +1,12 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getProducts, deleteProduct } from '../api/products.api';
 import type { ProductSearchParams, ProductStatus } from '../types/api.types';
 import { useAuthStore } from '../store/authStore';
+import AdminSidebar from '../components/layout/AdminSidebar';
 
 export default function AdminProductList() {
-  const navigate = useNavigate();
-  const { logout } = useAuthStore();
   const queryClient = useQueryClient();
   const [searchKeyword, setSearchKeyword] = useState('');
   const [statusFilter, setStatusFilter] = useState<ProductStatus | 'ALL'>('ALL');
@@ -94,96 +93,62 @@ export default function AdminProductList() {
     return statusMap[status] || statusMap.HIDDEN;
   };
 
-  const handleLogout = () => {
-    logout();
-    navigate('/login');
-  };
+  const { user } = useAuthStore();
 
   return (
-    <div className="bg-background-light dark:bg-background-dark font-display text-text-main dark:text-gray-100 transition-colors duration-200 flex h-screen w-full overflow-hidden">
-      {/* Sidebar */}
-      <aside className="w-64 bg-surface-light dark:bg-surface-dark border-r border-[#dbe6e3] dark:border-[#2a3c38] flex-shrink-0 flex flex-col transition-colors duration-200 z-20 hidden md:flex">
-        <div className="p-6 flex items-center gap-3">
-          <div className="bg-primary/20 bg-center bg-no-repeat bg-cover rounded-full size-10 flex items-center justify-center text-primary-content">
-            <span className="material-symbols-outlined">pets</span>
-          </div>
-          <div className="flex flex-col">
-            <h1 className="text-text-main dark:text-white text-lg font-bold leading-tight">PawBridge</h1>
-            <p className="text-text-sub dark:text-gray-400 text-xs font-medium">관리자 센터</p>
-          </div>
-        </div>
-        <nav className="flex-1 overflow-y-auto px-4 py-2 flex flex-col gap-2">
-          <Link
-            to="/admin/dashboard"
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-main dark:text-gray-200 hover:bg-background-light dark:hover:bg-background-dark transition-colors"
-          >
-            <span className="material-symbols-outlined text-text-sub dark:text-gray-400">dashboard</span>
-            <span className="text-sm font-medium">대시보드</span>
-          </Link>
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center gap-3 px-3 py-2.5 rounded-lg bg-primary/10 text-primary-content dark:text-primary font-medium">
-              <span className="material-symbols-outlined fill-current">inventory_2</span>
-              <span className="text-sm">상품 관리</span>
-            </div>
-            <div className="pl-11 pr-3 flex flex-col gap-1">
-              <Link
-                to="/admin/products"
-                className="py-2 text-sm font-bold text-primary dark:text-primary"
-              >
-                상품 목록
-              </Link>
-              <Link
-                to="/products/new"
-                className="py-2 text-sm text-text-sub dark:text-gray-400 hover:text-text-main dark:hover:text-gray-200 transition-colors"
-              >
-                상품 등록
-              </Link>
-            </div>
-          </div>
-          <Link
-            to="/admin/categories"
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-main dark:text-gray-200 hover:bg-background-light dark:hover:bg-background-dark transition-colors"
-          >
-            <span className="material-symbols-outlined text-text-sub dark:text-gray-400">category</span>
-            <span className="text-sm font-medium">카테고리 관리</span>
-          </Link>
-        </nav>
-        <div className="p-4 border-t border-[#dbe6e3] dark:border-[#2a3c38]">
-          <button
-            onClick={handleLogout}
-            className="flex items-center gap-3 px-3 py-2 text-text-sub dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors w-full"
-          >
-            <span className="material-symbols-outlined">logout</span>
-            <span className="text-sm font-medium">로그아웃</span>
-          </button>
-        </div>
-      </aside>
+    <div className="bg-background-light dark:bg-background-dark text-text-main dark:text-white h-screen overflow-hidden flex">
+      {/* 사이드바 */}
+      <AdminSidebar />
 
-      {/* Main Content */}
-      <main className="flex-1 flex flex-col h-full overflow-hidden relative">
-        {/* Mobile Header */}
-        <header className="md:hidden flex items-center justify-between p-4 bg-surface-light dark:bg-surface-dark border-b border-[#dbe6e3] dark:border-[#2a3c38]">
-          <div className="flex items-center gap-2">
-            <span className="material-symbols-outlined text-primary">pets</span>
-            <span className="font-bold">PawBridge</span>
+      {/* 메인 콘텐츠 */}
+      <main className="flex-1 flex flex-col min-w-0 h-full overflow-hidden bg-background-light dark:bg-background-dark relative">
+        {/* 헤더 */}
+        <header className="flex-none h-16 bg-surface-light dark:bg-surface-dark border-b border-[#e5e7eb] dark:border-gray-700 px-8 flex items-center justify-between z-10">
+          <div className="flex items-center gap-4">
+            <h2 className="text-xl font-bold text-text-main dark:text-white">상품 목록</h2>
           </div>
-          <button className="text-text-main dark:text-white">
-            <span className="material-symbols-outlined">menu</span>
-          </button>
+          <div className="flex items-center gap-6">
+            <div className="hidden md:flex items-center w-64 h-10 rounded-lg bg-background-light dark:bg-gray-800 px-3 border border-transparent focus-within:border-primary transition-colors">
+              <span className="material-symbols-outlined text-text-secondary">search</span>
+              <input
+                className="bg-transparent border-none outline-none text-sm ml-2 w-full text-text-main dark:text-white placeholder:text-text-secondary focus:ring-0"
+                placeholder="검색..."
+                type="text"
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <button className="size-10 rounded-full flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 text-text-main dark:text-white transition-colors relative">
+                <span className="material-symbols-outlined">notifications</span>
+                <span className="absolute top-2 right-2 size-2 bg-red-500 rounded-full border border-white dark:border-gray-800"></span>
+              </button>
+              <button className="flex items-center gap-2 pl-1 pr-3 py-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                <div
+                  className="size-8 rounded-full bg-cover bg-center border border-gray-200 bg-primary/20 flex items-center justify-center"
+                >
+                  <div className="w-full h-full flex items-center justify-center text-text-main font-bold text-xs">
+                    {user?.name?.charAt(0) || '관'}
+                  </div>
+                </div>
+                <span className="text-sm font-semibold text-text-main dark:text-white hidden lg:block">
+                  {user?.name || '관리자'}님
+                </span>
+              </button>
+            </div>
+          </div>
         </header>
 
-        {/* Page Content Scrollable Area */}
-        <div className="flex-1 overflow-y-auto p-4 md:p-8 lg:p-10 scroll-smooth">
+        {/* 콘텐츠 영역 */}
+        <div className="flex-1 overflow-y-auto p-8 bg-background-light dark:bg-background-dark">
           <div className="max-w-7xl mx-auto flex flex-col gap-6">
-            {/* Page Heading */}
-            <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
-              <div className="flex flex-col gap-2">
-                <h2 className="text-3xl font-bold text-text-main dark:text-white tracking-tight">상품 목록</h2>
-                <p className="text-text-sub dark:text-gray-400 text-sm">등록된 상품을 조회하고 재고 및 상태를 관리합니다.</p>
-              </div>
+            <div className="mb-4">
+              <p className="text-text-secondary dark:text-gray-400 text-sm">
+                등록된 상품을 조회하고 재고 및 상태를 관리합니다.
+              </p>
+            </div>
+            <div className="flex justify-end">
               <Link
                 to="/products/new"
-                className="flex items-center justify-center gap-2 bg-primary hover:bg-emerald-300 text-primary-content px-5 py-2.5 rounded-lg font-bold text-sm transition-all shadow-sm hover:shadow-md"
+                className="flex items-center justify-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg font-bold text-sm transition-all shadow-sm hover:shadow-md"
               >
                 <span className="material-symbols-outlined text-[20px]">add</span>
                 <span>상품 등록</span>

--- a/src/pages/AdminStatistics.tsx
+++ b/src/pages/AdminStatistics.tsx
@@ -116,24 +116,38 @@ export default function AdminStatistics() {
     <div className="bg-background-light dark:bg-background-dark text-text-main dark:text-white h-screen overflow-hidden flex">
       <AdminSidebar />
 
-      <main className="flex-1 flex flex-col h-full overflow-hidden bg-background-light dark:bg-background-dark relative">
+      <main className="flex-1 flex flex-col min-w-0 h-full overflow-hidden bg-background-light dark:bg-background-dark relative">
         {/* 헤더 */}
-        <header className="h-16 flex items-center justify-between px-8 bg-surface-light dark:bg-surface-dark border-b border-[#e5e7eb] dark:border-gray-700 shrink-0 z-10">
-          <div className="flex-1"></div>
+        <header className="flex-none h-16 bg-surface-light dark:bg-surface-dark border-b border-[#e5e7eb] dark:border-gray-700 px-8 flex items-center justify-between z-10">
           <div className="flex items-center gap-4">
-            <button className="p-2 text-text-sub dark:text-gray-400 hover:text-text-main hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors relative">
-              <span className="material-symbols-outlined">notifications</span>
-              <span className="absolute top-2.5 right-2.5 w-2 h-2 bg-red-500 rounded-full ring-2 ring-white dark:ring-gray-800"></span>
-            </button>
-            <div className="w-px h-8 bg-gray-200 dark:bg-gray-700"></div>
+            <h2 className="text-xl font-bold text-text-main dark:text-white">통계</h2>
+          </div>
+          <div className="flex items-center gap-6">
+            <div className="hidden md:flex items-center w-64 h-10 rounded-lg bg-background-light dark:bg-gray-800 px-3 border border-transparent focus-within:border-primary transition-colors">
+              <span className="material-symbols-outlined text-text-secondary">search</span>
+              <input
+                className="bg-transparent border-none outline-none text-sm ml-2 w-full text-text-main dark:text-white placeholder:text-text-secondary focus:ring-0"
+                placeholder="검색..."
+                type="text"
+              />
+            </div>
             <div className="flex items-center gap-3">
-              <div className="text-right hidden sm:block">
-                <p className="text-sm font-bold text-text-main dark:text-white">{user?.name || '관리자'}</p>
-                <p className="text-xs text-text-sub dark:text-gray-400">Super Admin</p>
-              </div>
-              <div className="h-9 w-9 rounded-full bg-primary/20 flex items-center justify-center border border-primary/30">
-                <span className="material-symbols-outlined text-primary text-[20px]">person</span>
-              </div>
+              <button className="size-10 rounded-full flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 text-text-main dark:text-white transition-colors relative">
+                <span className="material-symbols-outlined">notifications</span>
+                <span className="absolute top-2 right-2 size-2 bg-red-500 rounded-full border border-white dark:border-gray-800"></span>
+              </button>
+              <button className="flex items-center gap-2 pl-1 pr-3 py-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                <div
+                  className="size-8 rounded-full bg-cover bg-center border border-gray-200 bg-primary/20 flex items-center justify-center"
+                >
+                  <div className="w-full h-full flex items-center justify-center text-text-main font-bold text-xs">
+                    {user?.name?.charAt(0) || '관'}
+                  </div>
+                </div>
+                <span className="text-sm font-semibold text-text-main dark:text-white hidden lg:block">
+                  {user?.name || '관리자'}님
+                </span>
+              </button>
             </div>
           </div>
         </header>

--- a/src/pages/AdminUserManagement.tsx
+++ b/src/pages/AdminUserManagement.tsx
@@ -179,14 +179,15 @@ export default function AdminUserManagement() {
       <AdminSidebar />
 
       {/* 메인 콘텐츠 */}
-      <main className="flex-1 flex flex-col h-full relative overflow-hidden bg-background-light dark:bg-background-dark">
+      <main className="flex-1 flex flex-col min-w-0 h-full overflow-hidden bg-background-light dark:bg-background-dark relative">
         {/* 헤더 */}
-        <header className="h-20 flex-shrink-0 bg-surface-light dark:bg-surface-dark border-b border-[#dbe6e3] dark:border-gray-800 px-8 flex items-center justify-between z-10 sticky top-0">
-          <div className="flex-1 max-w-lg">
-            <div className="relative group">
-              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <span className="material-symbols-outlined text-text-sub dark:text-gray-400 group-focus-within:text-primary transition-colors">search</span>
-              </div>
+        <header className="flex-none h-16 bg-surface-light dark:bg-surface-dark border-b border-[#e5e7eb] dark:border-gray-700 px-8 flex items-center justify-between z-10">
+          <div className="flex items-center gap-4">
+            <h2 className="text-xl font-bold text-text-main dark:text-white">회원 관리</h2>
+          </div>
+          <div className="flex items-center gap-6">
+            <div className="hidden md:flex items-center w-64 h-10 rounded-lg bg-background-light dark:bg-gray-800 px-3 border border-transparent focus-within:border-primary transition-colors">
+              <span className="material-symbols-outlined text-text-secondary">search</span>
               <input
                 type="text"
                 value={searchKeyword}
@@ -194,35 +195,33 @@ export default function AdminUserManagement() {
                   setSearchKeyword(e.target.value);
                   setCurrentPage(0);
                 }}
-                placeholder="이메일 또는 닉네임으로 검색하세요..."
-                className="block w-full pl-10 pr-3 py-2.5 border-none bg-background-light/50 dark:bg-background-dark/50 rounded-lg text-text-main dark:text-white placeholder:text-text-sub dark:placeholder:text-gray-500 focus:ring-2 focus:ring-primary/50 focus:bg-white dark:focus:bg-black/20 transition-all text-sm"
+                placeholder="이메일 또는 닉네임으로 검색..."
+                className="bg-transparent border-none outline-none text-sm ml-2 w-full text-text-main dark:text-white placeholder:text-text-secondary focus:ring-0"
               />
             </div>
-          </div>
-          <div className="flex items-center gap-4 pl-8">
-            <button className="relative p-2 text-text-sub dark:text-gray-400 hover:text-primary hover:bg-[#f0f5f3] dark:hover:bg-gray-800 rounded-lg transition-colors">
-              <span className="material-symbols-outlined" style={{ fontVariationSettings: "'FILL' 0" }}>notifications</span>
-              <span className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-surface-light dark:border-surface-dark"></span>
-            </button>
-            <div className="h-8 w-px bg-[#dbe6e3] dark:bg-gray-700 mx-1"></div>
-            <div className="flex items-center gap-3 pl-1">
-              <div className="flex flex-col text-right hidden md:block">
-                <span className="text-sm font-bold text-text-main dark:text-white leading-none">{user?.name || '관리자'}</span>
-                <span className="text-xs text-text-sub dark:text-gray-400 mt-1">Super Admin</span>
-              </div>
-              <div className="w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden ring-2 ring-white dark:ring-gray-800 shadow-sm flex items-center justify-center">
-                {user?.name ? (
-                  <span className="text-text-main dark:text-white font-bold text-xs">{user.name.charAt(0)}</span>
-                ) : (
-                  <span className="material-symbols-outlined text-text-sub">person</span>
-                )}
-              </div>
+            <div className="flex items-center gap-3">
+              <button className="size-10 rounded-full flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 text-text-main dark:text-white transition-colors relative">
+                <span className="material-symbols-outlined">notifications</span>
+                <span className="absolute top-2 right-2 size-2 bg-red-500 rounded-full border border-white dark:border-gray-800"></span>
+              </button>
+              <button className="flex items-center gap-2 pl-1 pr-3 py-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                <div
+                  className="size-8 rounded-full bg-cover bg-center border border-gray-200 bg-primary/20 flex items-center justify-center"
+                >
+                  <div className="w-full h-full flex items-center justify-center text-text-main font-bold text-xs">
+                    {user?.name?.charAt(0) || '관'}
+                  </div>
+                </div>
+                <span className="text-sm font-semibold text-text-main dark:text-white hidden lg:block">
+                  {user?.name || '관리자'}님
+                </span>
+              </button>
             </div>
           </div>
         </header>
 
         {/* 콘텐츠 영역 */}
-        <div className="flex-1 overflow-auto p-8 no-scrollbar">
+        <div className="flex-1 overflow-y-auto p-8 bg-background-light dark:bg-background-dark">
           <div className="max-w-[1200px] mx-auto w-full flex flex-col gap-6">
             {/* 페이지 헤더 */}
             <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">

--- a/src/pages/AnimalCreate.tsx
+++ b/src/pages/AnimalCreate.tsx
@@ -1,0 +1,611 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { createAnimal, uploadAnimalImage } from '../api/animals.api';
+import { getMyInfo } from '../api/user.api';
+import type { CreateAnimalRequest } from '../api/animals.api';
+import { useAuthStore } from '../store/authStore';
+import CustomSelect from '../components/common/CustomSelect';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+
+export default function AnimalCreate() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  // 사용자 정보 조회 (보호소 등록번호 확인용)
+  const { data: userInfo } = useQuery({
+    queryKey: ['myInfo'],
+    queryFn: getMyInfo,
+  });
+
+  // authStore에서도 user 정보 가져오기 (로그인 시 저장된 careRegNo 사용)
+  const authUser = useAuthStore((state) => state.user);
+
+  // 기본 정보
+  const [species, setSpecies] = useState<'DOG' | 'CAT' | 'ETC'>('DOG');
+  const [breed, setBreed] = useState('');
+  const [gender, setGender] = useState<'MALE' | 'FEMALE' | 'UNKNOWN' | ''>('');
+  const [neuterStatus, setNeuterStatus] = useState<'YES' | 'NO' | 'UNKNOWN' | ''>('');
+  const [birthYear, setBirthYear] = useState<number | ''>('');
+  const [weight, setWeight] = useState('');
+  const [color, setColor] = useState('');
+  const [specialMark, setSpecialMark] = useState('');
+
+  // 발견 정보
+  const [happenDate, setHappenDate] = useState('');
+  const [happenPlace, setHappenPlace] = useState('');
+
+  // 공고 정보
+  const [noticeStartDate, setNoticeStartDate] = useState('');
+  const [noticeEndDate, setNoticeEndDate] = useState('');
+
+  // 설명
+  const [description, setDescription] = useState('');
+
+  // 이미지
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string>('');
+
+  // 이미지 파일 선택 (대표 이미지)
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      // 파일 크기 검증 (10MB)
+      if (file.size > 10 * 1024 * 1024) {
+        alert('이미지 파일 크기는 10MB 이하여야 합니다.');
+        return;
+      }
+      // 파일 타입 검증
+      const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
+      if (!allowedTypes.includes(file.type.toLowerCase())) {
+        alert('지원하는 이미지 형식은 JPEG, PNG, GIF, WEBP입니다.');
+        return;
+      }
+      setImageFile(file);
+      // 미리보기 생성
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImagePreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  // 이미지 제거 (대표 이미지)
+  const handleRemoveImage = () => {
+    setImageFile(null);
+    setImagePreview('');
+  };
+
+  // 이미지 업로드 mutation (단일)
+  const uploadImageMutation = useMutation({
+    mutationFn: uploadAnimalImage,
+  });
+
+
+  // 동물 등록 mutation
+  const createAnimalMutation = useMutation({
+    mutationFn: createAnimal,
+    onSuccess: (data) => {
+      // "내 보호소가 등록한 동물" 목록 캐시 무효화 (목록에도 반영되도록)
+      queryClient.invalidateQueries({ queryKey: ['registeredAnimals'] });
+      alert('동물이 등록되었습니다.');
+      // 등록한 동물의 상세 페이지로 이동 (등록 내용 확인)
+      navigate(`/animals/${data.id}`);
+    },
+    onError: (error: any) => {
+      const message = error.response?.data?.message || '동물 등록에 실패했습니다.';
+      alert(message);
+    },
+  });
+
+  // 폼 제출
+  const handleSubmit = async () => {
+    // 유효성 검증 (명세서 기준 필수 필드)
+    if (!species) {
+      alert('종을 선택해주세요.');
+      return;
+    }
+    if (!gender) {
+      alert('성별을 선택해주세요.');
+      return;
+    }
+    if (!neuterStatus) {
+      alert('중성화 여부를 선택해주세요.');
+      return;
+    }
+    if (!noticeStartDate) {
+      alert('공고 시작일을 입력해주세요.');
+      return;
+    }
+    if (!noticeEndDate) {
+      alert('공고 종료일을 입력해주세요.');
+      return;
+    }
+    // authStore의 user 또는 userInfo에서 careRegNo 가져오기
+    const careRegNo = authUser?.careRegNo || userInfo?.careRegNo;
+    
+    if (!userInfo && !authUser) {
+      alert('사용자 정보를 불러올 수 없습니다. 다시 로그인해주세요.');
+      return;
+    }
+    const userRole = authUser?.role || userInfo?.role;
+    if (userRole !== 'ROLE_SHELTER') {
+      alert('보호소 회원만 동물을 등록할 수 있습니다.');
+      return;
+    }
+    if (!careRegNo) {
+      alert('보호소 등록번호가 없습니다. 관리자에게 문의해주세요.');
+      return;
+    }
+
+    try {
+      let imageUrl = '';
+
+      // 대표 이미지 업로드
+      if (imageFile) {
+        const imageResponse = await uploadImageMutation.mutateAsync(imageFile);
+        imageUrl = imageResponse.imageUrl;
+        console.log('이미지 업로드 응답:', imageResponse);
+        console.log('추출된 imageUrl:', imageUrl);
+        
+        if (!imageUrl) {
+          alert('이미지 URL을 받아오지 못했습니다. 다시 시도해주세요.');
+          return;
+        }
+      }
+
+      // 동물 등록 (명세서 기준: careRegNo 사용, 필수 필드 포함, 선택 필드는 조건부 포함)
+      // 로그인 시 저장된 careRegNo 사용
+      const animalData: CreateAnimalRequest = {
+        careRegNo: careRegNo, // 로그인 시 저장된 careRegNo 사용
+        species,
+        status: 'PROTECT', // 보호소에서 등록하는 동물은 기본적으로 '보호중' 상태
+        noticeStartDate, // 필수
+        noticeEndDate, // 필수
+        gender: gender as 'MALE' | 'FEMALE' | 'UNKNOWN', // 필수 (UNKNOWN 포함)
+        neuterStatus: neuterStatus as 'YES' | 'NO' | 'UNKNOWN', // 필수 (UNKNOWN 포함)
+        apiSource: 'MANUAL', // 보호소가 직접 등록하는 동물은 MANUAL로 명시
+        // apmsNoticeNo는 선택 필드이므로 보내지 않으면 서버에서 자동 생성
+        ...(breed && { breed }),
+        ...(birthYear && { birthYear: Number(birthYear) }),
+        ...(weight && { weight }),
+        ...(color && { color }),
+        ...(specialMark && { specialMark }),
+        ...(happenDate && { happenDate }),
+        ...(happenPlace && { happenPlace }),
+        ...(imageUrl && { imageUrl }), // imageUrl이 있으면 포함
+        ...(description && { description }),
+      };
+
+      console.log('동물 등록 요청 데이터:', animalData);
+      console.log('imageUrl 포함 여부:', !!animalData.imageUrl);
+
+      await createAnimalMutation.mutateAsync(animalData);
+    } catch (error: any) {
+      const message = error.response?.data?.message || '이미지 업로드에 실패했습니다.';
+      alert(message);
+    }
+  };
+
+  // 보호소 권한 체크
+  if (userInfo && userInfo.role !== 'ROLE_SHELTER') {
+    return (
+      <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark">
+        <Header />
+        <main className="flex-1 flex items-center justify-center">
+          <div className="text-center">
+            <span className="material-symbols-outlined text-5xl text-red-500 mb-4">error</span>
+            <p className="text-gray-500 mb-4">보호소 회원만 동물을 등록할 수 있습니다.</p>
+            <Link
+              to="/mypage"
+              className="px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90"
+            >
+              마이페이지로 돌아가기
+            </Link>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  const user = useAuthStore((state) => state.user);
+  const clearAuth = useAuthStore((state) => state.clearAuth);
+
+  const handleLogout = () => {
+    clearAuth();
+    navigate('/login');
+  };
+
+  return (
+    <div className="bg-background-light dark:bg-background-dark text-[#111816] dark:text-gray-100 font-body h-screen flex overflow-hidden">
+      {/* 사이드바 */}
+      <aside className="w-64 bg-surface-light dark:bg-surface-dark border-r border-[#e0e8e5] dark:border-[#1f3530] flex flex-col flex-shrink-0 z-50">
+        {/* 로고 */}
+        <div className="h-16 flex items-center gap-3 px-6 border-b border-[#e0e8e5] dark:border-[#1f3530]">
+          <div className="size-8 text-primary">
+            <svg className="w-full h-full" fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+              <g clipPath="url(#clip0_6_330)">
+                <path clipRule="evenodd" d="M24 0.757355L47.2426 24L24 47.2426L0.757355 24L24 0.757355ZM21 35.7574V12.2426L9.24264 24L21 35.7574Z" fill="currentColor" fillRule="evenodd"></path>
+              </g>
+              <defs>
+                <clipPath id="clip0_6_330"><rect fill="white" height="48" width="48"></rect></clipPath>
+              </defs>
+            </svg>
+          </div>
+          <h1 className="text-xl font-display font-bold tracking-tight text-[#111816] dark:text-white">PawBridge</h1>
+        </div>
+        
+        {/* 네비게이션 */}
+        <nav className="flex-1 overflow-y-auto py-6 px-3 flex flex-col gap-1 scrollbar-hide">
+          <Link to="/mypage" className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[#5f8c80] hover:text-[#111816] hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] dark:hover:text-white transition-colors">
+            <span className="material-symbols-outlined text-[22px]">person</span>
+            <span className="text-sm font-medium">마이페이지</span>
+          </Link>
+          <div className="my-2 h-px bg-[#e0e8e5] dark:bg-[#1f3530] mx-3"></div>
+          <Link to="/animals" className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[#5f8c80] hover:text-[#111816] hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] dark:hover:text-white transition-colors">
+            <span className="material-symbols-outlined text-[22px]">pets</span>
+            <span className="text-sm font-medium">동물 목록</span>
+          </Link>
+          <div className="flex flex-col gap-1 mt-1">
+            <div className="flex items-center justify-between px-3 py-2.5 rounded-lg text-[#111816] dark:text-white bg-[#f0f5f3] dark:bg-[#1f3530] font-bold">
+              <div className="flex items-center gap-3">
+                <span className="material-symbols-outlined text-[22px] text-primary">pets</span>
+                <span className="text-sm">동물 관리</span>
+              </div>
+              <span className="material-symbols-outlined text-[18px]">expand_less</span>
+            </div>
+            <div className="flex flex-col pl-11 gap-1">
+              <Link to="/mypage" className="block px-3 py-2 rounded-lg text-sm text-[#5f8c80] hover:text-[#111816] hover:bg-[#f0f5f3] dark:hover:text-white dark:hover:bg-[#1f3530] transition-colors">
+                내 보호소가 등록한 동물
+              </Link>
+              <Link to="/animals/new" className="block px-3 py-2 rounded-lg text-sm font-bold text-primary bg-primary/10 transition-colors">
+                동물 등록
+              </Link>
+            </div>
+          </div>
+        </nav>
+        
+        {/* 하단 고객지원 */}
+        <div className="p-4 border-t border-[#e0e8e5] dark:border-[#1f3530]">
+          <button className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-bold text-[#5f8c80] hover:text-[#111816] dark:hover:text-white bg-transparent hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] rounded-lg transition-colors">
+            <span className="material-symbols-outlined text-[18px]">help</span>
+            고객지원
+          </button>
+        </div>
+      </aside>
+
+      {/* 메인 컨텐츠 영역 */}
+      <div className="flex-1 flex flex-col h-full overflow-hidden relative">
+        {/* 상단 헤더 */}
+        <header className="flex items-center justify-end h-16 px-8 border-b border-[#e0e8e5] dark:border-[#1f3530] bg-surface-light dark:bg-surface-dark flex-shrink-0">
+          <div className="flex items-center gap-6">
+            <button className="relative flex items-center gap-2 text-[#5f8c80] hover:text-primary transition-colors">
+              <span className="material-symbols-outlined text-[24px]">notifications</span>
+              <span className="absolute top-0 right-0 size-2.5 bg-red-500 rounded-full border-2 border-surface-light dark:border-surface-dark"></span>
+            </button>
+            <div className="h-6 w-px bg-[#e0e8e5] dark:border-[#1f3530]"></div>
+            <div className="flex items-center gap-3">
+              <div className="bg-center bg-no-repeat bg-cover rounded-full size-9 ring-2 ring-primary/20 bg-primary/20 flex items-center justify-center">
+                <span className="material-symbols-outlined text-primary">person</span>
+              </div>
+              <div className="hidden md:flex flex-col text-right">
+                <span className="text-sm font-bold leading-none text-[#111816] dark:text-white">{user?.name || '사용자'}</span>
+                <span className="text-xs text-[#5f8c80]">{user?.role === 'ROLE_SHELTER' ? '보호소' : user?.role === 'ROLE_ADMIN' ? '관리자' : '회원'}</span>
+              </div>
+            </div>
+            <button 
+              onClick={handleLogout}
+              className="flex items-center justify-center size-9 rounded-lg hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] text-[#5f8c80] hover:text-red-500 transition-colors ml-2"
+            >
+              <span className="material-symbols-outlined text-[20px]">logout</span>
+            </button>
+          </div>
+        </header>
+
+        {/* 메인 컨텐츠 */}
+        <main className="flex-1 overflow-y-auto bg-background-light dark:bg-background-dark p-6 md:p-10 pb-24">
+        <div className="max-w-5xl mx-auto flex flex-col gap-6">
+          {/* 브레드크럼 */}
+          <nav className="flex flex-wrap gap-2 text-sm font-medium">
+            <Link to="/" className="text-[#5f8c80] hover:text-primary transition-colors">
+              홈
+            </Link>
+            <span className="text-[#5f8c80] material-symbols-outlined text-[16px] pt-0.5">chevron_right</span>
+            <Link to="/mypage" className="text-[#5f8c80] hover:text-primary transition-colors">
+              마이페이지
+            </Link>
+            <span className="text-[#5f8c80] material-symbols-outlined text-[16px] pt-0.5">chevron_right</span>
+            <span className="text-[#111816] dark:text-white font-bold">동물 등록</span>
+          </nav>
+
+          {/* 페이지 제목 */}
+          <div className="flex flex-col md:flex-row justify-between items-start md:items-end gap-4 pb-2">
+            <div className="flex flex-col gap-2">
+              <h1 className="text-[#111816] dark:text-white text-3xl font-display font-black leading-tight tracking-tight">
+                동물 등록
+              </h1>
+              <p className="text-[#5f8c80] text-base font-normal">
+                보호소에서 보호 중인 동물을 등록하세요.
+              </p>
+            </div>
+          </div>
+
+          {/* 기본 정보 섹션 */}
+          <section className="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm border border-[#e0e8e5] dark:border-[#1f3530] overflow-hidden">
+            <div className="px-6 py-4 border-b border-[#f0f5f3] dark:border-[#1f3530] flex items-center gap-3 bg-[#fbfdfc] dark:bg-[#1a2e29]">
+            <div className="size-8 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold">
+              1
+            </div>
+            <h2 className="text-[#111816] dark:text-white text-lg font-bold">기본 정보</h2>
+          </div>
+          <div className="p-6 grid grid-cols-1 md:grid-cols-12 gap-6">
+            <div className="md:col-span-8 flex flex-col gap-5">
+                <label className="flex flex-col gap-2">
+                  <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">
+                    종 <span className="text-red-500">*</span>
+                  </span>
+                <CustomSelect
+                  value={species}
+                  onChange={(value) => setSpecies(value as 'DOG' | 'CAT' | 'ETC')}
+                  options={[
+                    { value: 'DOG', label: '강아지' },
+                    { value: 'CAT', label: '고양이' },
+                    { value: 'ETC', label: '기타' },
+                  ]}
+                  placeholder="종을 선택하세요"
+                />
+              </label>
+
+                <label className="flex flex-col gap-2">
+                  <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">품종</span>
+                  <input
+                    type="text"
+                    value={breed}
+                    onChange={(e) => setBreed(e.target.value)}
+                    placeholder="예: 믹스견, 라브라도 리트리버"
+                    className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                  />
+                </label>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <label className="flex flex-col gap-2">
+                    <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">
+                      성별 <span className="text-red-500">*</span>
+                    </span>
+                    <CustomSelect
+                      value={gender}
+                      onChange={(value) => setGender(value as 'MALE' | 'FEMALE' | 'UNKNOWN' | '')}
+                      options={[
+                        { value: 'MALE', label: '수컷' },
+                        { value: 'FEMALE', label: '암컷' },
+                        { value: 'UNKNOWN', label: '미상' },
+                      ]}
+                      placeholder="성별을 선택하세요"
+                    />
+                  </label>
+
+                  <label className="flex flex-col gap-2">
+                    <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">
+                      중성화 여부 <span className="text-red-500">*</span>
+                    </span>
+                    <CustomSelect
+                      value={neuterStatus}
+                      onChange={(value) => setNeuterStatus(value as 'YES' | 'NO' | 'UNKNOWN' | '')}
+                      options={[
+                        { value: 'YES', label: '중성화 완료' },
+                        { value: 'NO', label: '중성화 안 함' },
+                        { value: 'UNKNOWN', label: '미상' },
+                      ]}
+                      placeholder="중성화 여부를 선택하세요"
+                    />
+                  </label>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <label className="flex flex-col gap-2">
+                    <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">출생년도</span>
+                    <input
+                      type="number"
+                      value={birthYear}
+                      onChange={(e) => setBirthYear(e.target.value ? Number(e.target.value) : '')}
+                      placeholder="예: 2023"
+                      min="1900"
+                      max={new Date().getFullYear()}
+                      className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                    />
+                  </label>
+
+                  <label className="flex flex-col gap-2">
+                    <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">체중</span>
+                    <input
+                      type="text"
+                      value={weight}
+                      onChange={(e) => setWeight(e.target.value)}
+                      placeholder="예: 5.5kg"
+                      className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                    />
+                  </label>
+                </div>
+
+                <label className="flex flex-col gap-2">
+                  <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">색상</span>
+                  <input
+                    type="text"
+                    value={color}
+                    onChange={(e) => setColor(e.target.value)}
+                    placeholder="예: 갈색, 흰색"
+                    className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                  />
+                </label>
+
+                <label className="flex flex-col gap-2">
+                  <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">특이사항</span>
+                  <textarea
+                    value={specialMark}
+                    onChange={(e) => setSpecialMark(e.target.value)}
+                    placeholder="동물의 특징이나 특이사항을 입력해주세요."
+                    rows={3}
+                    className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all resize-y"
+                  />
+                </label>
+              </div>
+
+              {/* 이미지 업로드 영역 */}
+              <div className="md:col-span-4 flex flex-col gap-2">
+                <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">
+                  대표 이미지 <span className="text-red-500">*</span>
+                </span>
+                {imagePreview ? (
+                  <div className="relative flex-1 min-h-[240px]">
+                    <img
+                      src={imagePreview}
+                      alt="대표 이미지 미리보기"
+                      className="w-full h-full object-cover rounded-xl border border-[#e0e8e5] dark:border-[#2a453d]"
+                    />
+                    <button
+                      onClick={handleRemoveImage}
+                      className="absolute top-2 right-2 rounded-full bg-red-500 text-white p-2 hover:bg-red-600 transition-colors"
+                    >
+                      <span className="material-symbols-outlined text-sm">close</span>
+                    </button>
+                  </div>
+                ) : (
+                  <label className="flex-1 min-h-[240px] border-2 border-dashed border-[#dbe6e3] dark:border-[#2a453d] rounded-xl bg-[#f8fbfb] dark:bg-[#122822] flex flex-col items-center justify-center gap-3 p-4 text-center cursor-pointer hover:border-primary hover:bg-primary/5 transition-colors group/upload">
+                    <div className="size-14 rounded-full bg-white dark:bg-[#1a2e29] shadow-sm flex items-center justify-center text-[#5f8c80] group-hover/upload:text-primary transition-colors border border-[#e0e8e5] dark:border-[#2a453d]">
+                      <span className="material-symbols-outlined text-[32px]">add_photo_alternate</span>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <p className="text-sm font-bold text-[#111816] dark:text-white group-hover/upload:text-primary transition-colors">
+                        클릭하여 이미지 업로드
+                      </p>
+                      <p className="text-xs text-[#5f8c80]">SVG, PNG, JPG (최대 10MB)</p>
+                    </div>
+                    <input
+                      type="file"
+                      accept="image/jpeg,image/jpg,image/png,image/gif,image/webp"
+                      onChange={handleImageChange}
+                      className="hidden"
+                    />
+                  </label>
+                )}
+              </div>
+          </div>
+        </section>
+
+        {/* 발견 정보 섹션 */}
+        <section className="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm border border-[#e0e8e5] dark:border-[#1f3530] overflow-hidden">
+          <div className="px-6 py-4 border-b border-[#f0f5f3] dark:border-[#1f3530] flex items-center gap-3 bg-[#fbfdfc] dark:bg-[#1a2e29]">
+            <div className="size-8 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold font-display">2</div>
+            <h2 className="text-[#111816] dark:text-white text-lg font-bold">발견 정보</h2>
+          </div>
+          <div className="p-6 grid grid-cols-1 md:grid-cols-12 gap-6">
+            <div className="md:col-span-8 flex flex-col gap-5">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <label className="flex flex-col gap-2">
+                  <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">발견 일자</span>
+                  <input
+                    type="date"
+                    value={happenDate}
+                    onChange={(e) => setHappenDate(e.target.value)}
+                    className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                  />
+                </label>
+
+                <label className="flex flex-col gap-2">
+                  <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">발견 장소</span>
+                  <input
+                    type="text"
+                    value={happenPlace}
+                    onChange={(e) => setHappenPlace(e.target.value)}
+                    placeholder="예: 서울시 강남구 역삼동"
+                    className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                  />
+                </label>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* 공고 정보 섹션 */}
+        <section className="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm border border-[#e0e8e5] dark:border-[#1f3530] overflow-hidden">
+          <div className="px-6 py-4 border-b border-[#f0f5f3] dark:border-[#1f3530] flex items-center gap-3 bg-[#fbfdfc] dark:bg-[#1a2e29]">
+            <div className="size-8 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold font-display">3</div>
+            <h2 className="text-[#111816] dark:text-white text-lg font-bold">공고 정보</h2>
+          </div>
+          <div className="p-6 grid grid-cols-1 md:grid-cols-12 gap-6">
+            <div className="md:col-span-8 flex flex-col gap-5">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <label className="flex flex-col gap-2">
+                  <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">공고 시작일</span>
+                  <input
+                    type="date"
+                    value={noticeStartDate}
+                    onChange={(e) => setNoticeStartDate(e.target.value)}
+                    className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                  />
+                </label>
+
+                <label className="flex flex-col gap-2">
+                  <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">공고 종료일</span>
+                  <input
+                    type="date"
+                    value={noticeEndDate}
+                    onChange={(e) => setNoticeEndDate(e.target.value)}
+                    className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                  />
+                </label>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* 설명 섹션 */}
+        <section className="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm border border-[#e0e8e5] dark:border-[#1f3530] overflow-hidden">
+          <div className="px-6 py-4 border-b border-[#f0f5f3] dark:border-[#1f3530] flex items-center gap-3 bg-[#fbfdfc] dark:bg-[#1a2e29]">
+            <div className="size-8 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold font-display">4</div>
+            <h2 className="text-[#111816] dark:text-white text-lg font-bold">보호소 설명</h2>
+          </div>
+          <div className="p-6 grid grid-cols-1 md:grid-cols-12 gap-6">
+            <div className="md:col-span-8 flex flex-col gap-5">
+              <label className="flex flex-col gap-2">
+                <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">상세 설명</span>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="동물에 대한 상세한 설명을 입력해주세요."
+                  rows={6}
+                  className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all resize-y"
+                />
+              </label>
+            </div>
+          </div>
+        </section>
+
+          {/* 버튼 영역 */}
+          <div className="flex justify-end gap-4 pt-6 border-t border-[#e0e8e5] dark:border-[#1f3530]">
+            <Link
+              to="/mypage"
+              className="px-4 py-2 text-sm font-bold text-[#5f8c80] bg-transparent border border-[#dbe6e3] rounded-lg hover:bg-white hover:text-primary dark:border-[#1f3530] dark:hover:bg-[#1f3530] transition-colors"
+            >
+              취소
+            </Link>
+            <button
+              onClick={handleSubmit}
+              disabled={createAnimalMutation.isPending || uploadImageMutation.isPending}
+              className="px-4 py-2 text-sm font-bold text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {createAnimalMutation.isPending || uploadImageMutation.isPending
+                ? '등록 중...'
+                : '등록하기'}
+            </button>
+          </div>
+        </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/AnimalDetail.tsx
+++ b/src/pages/AnimalDetail.tsx
@@ -1,23 +1,97 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getAnimalById, checkFavorite, addFavorite, removeFavorite } from '../api/animals.api';
 import { useAuthStore } from '../store/authStore';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function AnimalDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const user = useAuthStore((state) => state.user);
   const [selectedImage, setSelectedImage] = useState<string>('');
+
+  // 이전 페이지 정보 확인 (마이페이지에서 온 경우)
+  const fromMyPage = location.state?.from === 'mypage';
+  const previousTab = location.state?.tab || sessionStorage.getItem('mypageActiveTab') || 'registeredAnimals';
+  
+  // 마이페이지에서 온 경우 sessionStorage에 탭 정보 저장
+  useEffect(() => {
+    if (fromMyPage && previousTab) {
+      sessionStorage.setItem('mypageActiveTab', previousTab);
+    }
+  }, [fromMyPage, previousTab]);
+
+  // 브라우저 뒤로가기 감지 및 처리
+  useEffect(() => {
+    const handlePopState = () => {
+      // 뒤로가기 시 sessionStorage의 탭 정보를 유지
+      if (fromMyPage && previousTab) {
+        sessionStorage.setItem('mypageActiveTab', previousTab);
+      }
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [fromMyPage, previousTab]);
 
   const { data: animal, isLoading, error } = useQuery({
     queryKey: ['animal', id],
     queryFn: () => getAnimalById(Number(id)),
     enabled: !!id,
   });
+
+  // 본인이 등록한 동물인지 확인 (보호소가 직접 등록한 동물만 수정 가능)
+  // apiSource가 MANUAL이거나 apmsNoticeNo가 MAN-으로 시작하고 careRegNo가 일치하는 경우만
+  const isManualAnimal = animal && (
+    animal.apiSource === 'MANUAL' || 
+    (animal.apmsNoticeNo && animal.apmsNoticeNo.startsWith('MAN-'))
+  );
+  
+  // careRegNo는 로그인할 때 주어지므로 무조건 비교해야 함 (등록한 것만 수정 가능)
+  // 하지만 API 응답에 careRegNo가 없을 수 있으므로, shelterId로도 비교
+  const isMyShelter = user?.role === 'ROLE_SHELTER' && (
+    (user?.careRegNo && animal?.careRegNo && user.careRegNo === animal.careRegNo) ||
+    (user?.id && animal?.shelterId && Number(user.id) === Number(animal.shelterId))
+  );
+  
+  const isMyAnimal = animal && 
+    isMyShelter &&
+    isManualAnimal;
+
+  // 디버깅: 수정 버튼 표시 조건 확인
+  useEffect(() => {
+    if (animal && user) {
+      console.log('=== 수정 버튼 표시 조건 확인 ===');
+      console.log('전체 animal 객체:', animal);
+      console.log('전체 user 객체:', user);
+      console.log('user.role:', user.role);
+      console.log('animal.apiSource:', animal.apiSource);
+      console.log('animal.apmsNoticeNo:', animal.apmsNoticeNo);
+      console.log('isManualAnimal:', isManualAnimal);
+      console.log('user.careRegNo:', user.careRegNo);
+      console.log('animal.careRegNo:', animal.careRegNo);
+      console.log('user.id:', user.id);
+      console.log('animal.shelterId:', animal.shelterId);
+      console.log('careRegNo 비교:', user.careRegNo, '===', animal.careRegNo, '?', user.careRegNo === animal.careRegNo);
+      console.log('shelterId 비교:', Number(user.id), '===', Number(animal.shelterId), '?', Number(user.id) === Number(animal.shelterId));
+      console.log('isMyShelter:', isMyShelter);
+      console.log('isMyAnimal:', isMyAnimal);
+      console.log('조건 체크:', {
+        hasAnimal: !!animal,
+        isShelter: user?.role === 'ROLE_SHELTER',
+        isManual: isManualAnimal,
+        hasUserCareRegNo: !!user?.careRegNo,
+        hasAnimalCareRegNo: !!animal.careRegNo,
+        careRegNoMatch: user?.careRegNo === animal.careRegNo,
+      });
+    }
+  }, [animal, user, isManualAnimal, isMyShelter, isMyAnimal]);
 
   // 찜 여부 확인
   const { data: isFavorited } = useQuery({
@@ -170,9 +244,27 @@ export default function AnimalDetail() {
               홈
             </button>
             <span className="text-secondary dark:text-primary">/</span>
-            <button onClick={() => navigate('/animals')} className="text-secondary dark:text-primary hover:underline">
-              보호동물 찾기
-            </button>
+            {fromMyPage ? (
+              <>
+                <button 
+                  onClick={() => navigate('/mypage', { state: { tab: previousTab } })}
+                  className="text-secondary dark:text-primary hover:underline"
+                >
+                  마이페이지
+                </button>
+                <span className="text-secondary dark:text-primary">/</span>
+                <button 
+                  onClick={() => navigate('/mypage', { state: { tab: previousTab } })}
+                  className="text-secondary dark:text-primary hover:underline"
+                >
+                  내 보호소가 등록한 동물
+                </button>
+              </>
+            ) : (
+              <button onClick={() => navigate('/animals')} className="text-secondary dark:text-primary hover:underline">
+                보호동물 찾기
+              </button>
+            )}
             <span className="text-secondary dark:text-primary">/</span>
             <span className="font-medium text-text-light dark:text-text-dark">[{speciesLabel}] {animal.breed}</span>
           </div>
@@ -217,34 +309,18 @@ export default function AnimalDetail() {
           <div className="lg:col-span-2 flex flex-col gap-6">
             {/* Basic Info Card */}
             <div className="bg-white/50 dark:bg-card-dark/50 p-6 rounded-xl shadow-md">
-              <div className="flex flex-wrap justify-between items-start gap-3 mb-4">
-                <div className="flex-1">
-                  <div className="flex items-start gap-3">
-                    <div className="flex-1">
-                      <p className="text-4xl font-black leading-tight tracking-[-0.033em] text-text-light dark:text-text-dark">
-                        [{speciesLabel}] {animal.breed}
-                      </p>
-                      <p className="text-sm text-secondary dark:text-gray-400 mt-1">
-                        공고번호: {animal.apmsNoticeNo || animal.noticeNo || 'N/A'}
-                      </p>
-                    </div>
-                    {/* 찜 버튼 */}
-                    <button
-                      onClick={handleFavoriteToggle}
-                      disabled={addFavoriteMutation.isPending || removeFavoriteMutation.isPending}
-                      className={`flex items-center justify-center w-12 h-12 rounded-full transition-all ${
-                        isFavorited
-                          ? 'bg-red-500 hover:bg-red-600 text-white'
-                          : 'bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-600 dark:text-gray-300'
-                      } disabled:opacity-50 disabled:cursor-not-allowed`}
-                      title={isFavorited ? '찜 해제' : '찜하기'}
-                    >
-                      <span className="material-symbols-outlined" style={{ fontVariationSettings: isFavorited ? "'FILL' 1" : "'FILL' 0" }}>
-                        favorite
-                      </span>
-                    </button>
-                  </div>
-                </div>
+              {/* 이름과 공고번호 영역 */}
+              <div className="mb-4">
+                <p className="text-4xl font-black leading-tight tracking-[-0.033em] text-text-light dark:text-text-dark">
+                  [{speciesLabel}] {animal.breed}
+                </p>
+                <p className="text-sm text-secondary dark:text-gray-400 mt-1">
+                  공고번호: {animal.apmsNoticeNo || animal.noticeNo || 'N/A'}
+                </p>
+              </div>
+
+              {/* 상태 태그, 찜 버튼, 수정 버튼 영역 */}
+              <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
                 <div className="flex items-center gap-2">
                   <div className="flex h-8 shrink-0 items-center justify-center gap-x-2 rounded-full bg-primary/20 dark:bg-primary/30 px-4">
                     <p className="text-primary dark:text-primary text-sm font-bold">
@@ -261,6 +337,34 @@ export default function AnimalDetail() {
                         D-{dDay}
                       </p>
                     </div>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  {/* 찜 버튼 */}
+                  <button
+                    onClick={handleFavoriteToggle}
+                    disabled={addFavoriteMutation.isPending || removeFavoriteMutation.isPending}
+                    className={`flex items-center justify-center w-12 h-12 rounded-full transition-all ${
+                      isFavorited
+                        ? 'bg-red-500 hover:bg-red-600 text-white'
+                        : 'bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-600 dark:text-gray-300'
+                    } disabled:opacity-50 disabled:cursor-not-allowed`}
+                    title={isFavorited ? '찜 해제' : '찜하기'}
+                  >
+                    <span className="material-symbols-outlined" style={{ fontVariationSettings: isFavorited ? "'FILL' 1" : "'FILL' 0" }}>
+                      favorite
+                    </span>
+                  </button>
+                  {/* 수정 버튼 (본인이 등록한 동물인 경우만) */}
+                  {isMyAnimal && (
+                    <Link
+                      to={`/animals/${id}/edit`}
+                      state={{ from: fromMyPage ? 'mypage' : undefined, tab: previousTab }}
+                      className="flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors font-bold text-sm"
+                    >
+                      <span className="material-symbols-outlined text-[18px]">edit</span>
+                      수정하기
+                    </Link>
                   )}
                 </div>
               </div>

--- a/src/pages/AnimalEdit.tsx
+++ b/src/pages/AnimalEdit.tsx
@@ -1,0 +1,573 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, Link, useParams, useLocation } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getAnimalById, updateAnimal, uploadAnimalImage } from '../api/animals.api';
+import type { UpdateAnimalRequest } from '../api/animals.api';
+import { useAuthStore } from '../store/authStore';
+import CustomSelect from '../components/common/CustomSelect';
+import AdminSidebar from '../components/layout/AdminSidebar';
+
+export default function AnimalEdit() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+
+  // 이전 페이지 정보 확인
+  const fromMyPage = location.state?.from === 'mypage';
+  const previousTab = location.state?.tab;
+
+  // 동물 정보 조회
+  const { data: animal, isLoading: isLoadingAnimal, error: animalError } = useQuery({
+    queryKey: ['animal', id],
+    queryFn: () => getAnimalById(Number(id)),
+    enabled: !!id,
+  });
+
+  const authUser = useAuthStore((state) => state.user);
+
+  // 폼 상태
+  const [species, setSpecies] = useState<'DOG' | 'CAT' | 'ETC'>('DOG');
+  const [breed, setBreed] = useState('');
+  const [gender, setGender] = useState<'MALE' | 'FEMALE' | 'UNKNOWN' | ''>('');
+  const [neuterStatus, setNeuterStatus] = useState<'YES' | 'NO' | 'UNKNOWN' | ''>('');
+  const [birthYear, setBirthYear] = useState<number | ''>('');
+  const [weight, setWeight] = useState('');
+  const [color, setColor] = useState('');
+  const [specialMark, setSpecialMark] = useState('');
+
+  const [happenDate, setHappenDate] = useState('');
+  const [happenPlace, setHappenPlace] = useState('');
+
+  const [noticeStartDate, setNoticeStartDate] = useState('');
+  const [noticeEndDate, setNoticeEndDate] = useState('');
+
+  const [description, setDescription] = useState('');
+
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string>('');
+
+  // 동물 정보 로드 시 폼 초기화
+  useEffect(() => {
+    if (animal) {
+      setSpecies((animal.species as 'DOG' | 'CAT' | 'ETC') || 'DOG');
+      setBreed(animal.breed || '');
+      setGender((animal.gender as 'MALE' | 'FEMALE' | 'UNKNOWN') || '');
+      setNeuterStatus((animal.neuterStatus as 'YES' | 'NO' | 'UNKNOWN') || '');
+      setBirthYear(animal.birthYear || '');
+      setWeight(animal.weight?.toString() || '');
+      setColor(animal.color || '');
+      setSpecialMark(animal.specialMark || '');
+      setHappenDate(animal.happenDate?.split('T')[0] || '');
+      setHappenPlace(animal.happenPlace || '');
+      setNoticeStartDate(animal.noticeStartDate?.split('T')[0] || '');
+      setNoticeEndDate(animal.noticeEndDate?.split('T')[0] || '');
+      setDescription(animal.description || '');
+      setImagePreview(animal.imageUrl || '');
+    }
+  }, [animal]);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      if (file.size > 10 * 1024 * 1024) {
+        alert('이미지 파일 크기는 10MB 이하여야 합니다.');
+        return;
+      }
+      const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
+      if (!allowedTypes.includes(file.type.toLowerCase())) {
+        alert('지원하는 이미지 형식은 JPEG, PNG, GIF, WEBP입니다.');
+        return;
+      }
+      setImageFile(file);
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImagePreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleRemoveImage = () => {
+    setImageFile(null);
+    setImagePreview(animal?.imageUrl || '');
+  };
+
+  const uploadImageMutation = useMutation({
+    mutationFn: uploadAnimalImage,
+  });
+
+  const updateAnimalMutation = useMutation({
+    mutationFn: (animalData: UpdateAnimalRequest) => updateAnimal(Number(id!), animalData),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['animal', id] });
+      queryClient.invalidateQueries({ queryKey: ['registeredAnimals'] });
+      alert('동물 정보가 수정되었습니다.');
+      navigate(`/animals/${data.id}`, { state: { from: fromMyPage ? 'mypage' : undefined, tab: previousTab } });
+    },
+    onError: (error: any) => {
+      const message = error.response?.data?.message || '동물 정보 수정에 실패했습니다.';
+      alert(message);
+    },
+  });
+
+  const handleSubmit = async () => {
+    if (!species) {
+      alert('종을 선택해주세요.');
+      return;
+    }
+    if (!gender) {
+      alert('성별을 선택해주세요.');
+      return;
+    }
+    if (!neuterStatus) {
+      alert('중성화 여부를 선택해주세요.');
+      return;
+    }
+    if (!noticeStartDate) {
+      alert('공고 시작일을 입력해주세요.');
+      return;
+    }
+    if (!noticeEndDate) {
+      alert('공고 종료일을 입력해주세요.');
+      return;
+    }
+
+    try {
+      let imageUrl = '';
+
+      if (imageFile) {
+        const imageResponse = await uploadImageMutation.mutateAsync(imageFile);
+        imageUrl = imageResponse.imageUrl;
+        if (!imageUrl) {
+          alert('이미지 URL을 받아오지 못했습니다. 다시 시도해주세요.');
+          return;
+        }
+      } else if (animal?.imageUrl) {
+        // 새 이미지를 업로드하지 않았으면 기존 이미지 URL 사용
+        imageUrl = animal.imageUrl;
+      }
+
+      // status 타입 변환 (Animal의 status를 UpdateAnimalRequest의 status로 변환)
+      let status: 'PROTECT' | 'ADOPTION_PENDING' | 'ADOPTED' | 'EUTHANIZED' | 'NATURAL_DEATH' | 'RETURNED' | 'DONATED' | 'RELEASED' | 'ESCAPED' | 'UNKNOWN' = 'PROTECT';
+      if (animal?.status) {
+        if (['PROTECT', 'ADOPTION_PENDING', 'ADOPTED', 'EUTHANIZED', 'NATURAL_DEATH', 'RETURNED', 'DONATED', 'RELEASED', 'ESCAPED', 'UNKNOWN'].includes(animal.status)) {
+          status = animal.status as typeof status;
+        }
+      }
+
+      const animalData: UpdateAnimalRequest = {
+        species,
+        status,
+        noticeStartDate,
+        noticeEndDate,
+        gender: gender as 'MALE' | 'FEMALE' | 'UNKNOWN',
+        neuterStatus: neuterStatus as 'YES' | 'NO' | 'UNKNOWN',
+        ...(breed && { breed }),
+        ...(birthYear && { birthYear: Number(birthYear) }),
+        ...(weight && { weight }),
+        ...(color && { color }),
+        ...(specialMark && { specialMark }),
+        ...(happenDate && { happenDate }),
+        ...(happenPlace && { happenPlace }),
+        ...(imageUrl && { imageUrl }),
+        ...(description && { description }),
+      };
+
+      await updateAnimalMutation.mutateAsync(animalData);
+    } catch (error: any) {
+      const message = error.response?.data?.message || '이미지 업로드 또는 동물 정보 수정에 실패했습니다.';
+      alert(message);
+    }
+  };
+
+  if (isLoadingAnimal) {
+    return (
+      <div className="bg-background-light dark:bg-background-dark text-[#111816] dark:text-gray-100 font-body h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="text-gray-500">동물 정보를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (animalError || !animal) {
+    return (
+      <div className="bg-background-light dark:bg-background-dark text-[#111816] dark:text-gray-100 font-body h-screen flex items-center justify-center">
+        <div className="text-center">
+          <span className="material-symbols-outlined text-5xl text-red-500 mb-4">error</span>
+          <p className="text-gray-500 mb-4">동물 정보를 불러올 수 없습니다.</p>
+          <Link
+            to={fromMyPage ? '/mypage' : '/animals'}
+            className="px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90"
+          >
+            돌아가기
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // 권한 체크 (보호소가 직접 등록한 동물만 수정 가능)
+  const isMyAnimal = animal && 
+    authUser?.role === 'ROLE_SHELTER' &&
+    animal.apiSource === 'MANUAL' &&
+    authUser?.careRegNo &&
+    animal.careRegNo &&
+    authUser.careRegNo === animal.careRegNo;
+
+  if (!isMyAnimal) {
+    return (
+      <div className="bg-background-light dark:bg-background-dark text-[#111816] dark:text-gray-100 font-body h-screen flex items-center justify-center">
+        <div className="text-center">
+          <span className="material-symbols-outlined text-5xl text-red-500 mb-4">error</span>
+          <p className="text-gray-500 mb-4">보호소가 직접 등록한 동물만 수정할 수 있습니다.</p>
+          <Link
+            to={`/animals/${id}`}
+            className="px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90"
+          >
+            돌아가기
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const user = useAuthStore((state) => state.user);
+  const clearAuth = useAuthStore((state) => state.clearAuth);
+
+  const handleLogout = () => {
+    clearAuth();
+    navigate('/login');
+  };
+
+  return (
+    <div className="bg-background-light dark:bg-background-dark text-[#111816] dark:text-gray-100 font-body h-screen flex overflow-hidden">
+      <AdminSidebar />
+      <div className="flex-1 flex flex-col h-full overflow-hidden relative">
+        <header className="flex items-center justify-end h-16 px-8 border-b border-[#e0e8e5] dark:border-[#1f3530] bg-surface-light dark:bg-surface-dark flex-shrink-0">
+          <div className="flex items-center gap-6">
+            <button className="relative flex items-center gap-2 text-[#5f8c80] hover:text-primary transition-colors">
+              <span className="material-symbols-outlined text-[24px]">notifications</span>
+              <span className="absolute top-0 right-0 size-2.5 bg-red-500 rounded-full border-2 border-surface-light dark:border-surface-dark"></span>
+            </button>
+            <div className="h-6 w-px bg-[#e0e8e5] dark:border-[#1f3530]"></div>
+            <div className="flex items-center gap-3">
+              <div className="bg-center bg-no-repeat bg-cover rounded-full size-9 ring-2 ring-primary/20 bg-primary/20 flex items-center justify-center">
+                <span className="material-symbols-outlined text-primary">person</span>
+              </div>
+              <div className="hidden md:flex flex-col text-right">
+                <span className="text-sm font-bold leading-none text-[#111816] dark:text-white">{user?.name || '사용자'}</span>
+                <span className="text-xs text-[#5f8c80]">{user?.role === 'ROLE_SHELTER' ? '보호소' : user?.role === 'ROLE_ADMIN' ? '관리자' : '회원'}</span>
+              </div>
+            </div>
+            <button
+              onClick={handleLogout}
+              className="flex items-center justify-center size-9 rounded-lg hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] text-[#5f8c80] hover:text-red-500 transition-colors ml-2"
+            >
+              <span className="material-symbols-outlined text-[20px]">logout</span>
+            </button>
+          </div>
+        </header>
+
+        <main className="flex-1 overflow-y-auto bg-background-light dark:bg-background-dark p-6 md:p-10 pb-24">
+          <div className="max-w-5xl mx-auto flex flex-col gap-6">
+            <nav className="flex flex-wrap gap-2 text-sm font-medium">
+              <Link to="/" className="text-[#5f8c80] hover:text-primary transition-colors">
+                홈
+              </Link>
+              <span className="text-[#5f8c80] material-symbols-outlined text-[16px] pt-0.5">chevron_right</span>
+              <Link to="/mypage" className="text-[#5f8c80] hover:text-primary transition-colors">
+                마이페이지
+              </Link>
+              <span className="text-[#5f8c80] material-symbols-outlined text-[16px] pt-0.5">chevron_right</span>
+              <span className="text-[#111816] dark:text-white font-bold">동물 수정</span>
+            </nav>
+
+            <div className="flex flex-col md:flex-row justify-between items-start md:items-end gap-4 pb-2">
+              <div className="flex flex-col gap-2">
+                <h1 className="text-[#111816] dark:text-white text-3xl font-display font-black leading-tight tracking-tight">
+                  동물 수정
+                </h1>
+                <p className="text-[#5f8c80] text-base font-normal">
+                  등록한 동물의 정보를 수정하세요.
+                </p>
+              </div>
+            </div>
+
+            <section className="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm border border-[#e0e8e5] dark:border-[#1f3530] overflow-hidden">
+              <div className="px-6 py-4 border-b border-[#f0f5f3] dark:border-[#1f3530] flex items-center gap-3 bg-[#fbfdfc] dark:bg-[#1a2e29]">
+                <div className="size-8 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold">
+                  1
+                </div>
+                <h2 className="text-[#111816] dark:text-white text-lg font-bold">기본 정보</h2>
+              </div>
+              <div className="p-6 grid grid-cols-1 md:grid-cols-12 gap-6">
+                <div className="md:col-span-8 flex flex-col gap-5">
+                  <label className="flex flex-col gap-2">
+                    <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">
+                      종 <span className="text-red-500">*</span>
+                    </span>
+                    <CustomSelect
+                      value={species}
+                      onChange={(value) => setSpecies(value as 'DOG' | 'CAT' | 'ETC')}
+                      options={[
+                        { value: 'DOG', label: '강아지' },
+                        { value: 'CAT', label: '고양이' },
+                        { value: 'ETC', label: '기타' },
+                      ]}
+                      placeholder="종을 선택하세요"
+                    />
+                  </label>
+
+                  <label className="flex flex-col gap-2">
+                    <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">품종</span>
+                    <input
+                      type="text"
+                      value={breed}
+                      onChange={(e) => setBreed(e.target.value)}
+                      placeholder="예: 믹스견, 라브라도 리트리버"
+                      className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                    />
+                  </label>
+
+                  <div className="grid grid-cols-2 gap-4">
+                    <label className="flex flex-col gap-2">
+                      <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">
+                        성별 <span className="text-red-500">*</span>
+                      </span>
+                      <CustomSelect
+                        value={gender}
+                        onChange={(value) => setGender(value as 'MALE' | 'FEMALE' | 'UNKNOWN' | '')}
+                        options={[
+                          { value: 'MALE', label: '수컷' },
+                          { value: 'FEMALE', label: '암컷' },
+                          { value: 'UNKNOWN', label: '미상' },
+                        ]}
+                        placeholder="성별을 선택하세요"
+                      />
+                    </label>
+
+                    <label className="flex flex-col gap-2">
+                      <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">
+                        중성화 여부 <span className="text-red-500">*</span>
+                      </span>
+                      <CustomSelect
+                        value={neuterStatus}
+                        onChange={(value) => setNeuterStatus(value as 'YES' | 'NO' | 'UNKNOWN' | '')}
+                        options={[
+                          { value: 'YES', label: '중성화 완료' },
+                          { value: 'NO', label: '중성화 안 함' },
+                          { value: 'UNKNOWN', label: '미상' },
+                        ]}
+                        placeholder="중성화 여부를 선택하세요"
+                      />
+                    </label>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-4">
+                    <label className="flex flex-col gap-2">
+                      <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">출생년도</span>
+                      <input
+                        type="number"
+                        value={birthYear}
+                        onChange={(e) => setBirthYear(e.target.value ? Number(e.target.value) : '')}
+                        placeholder="예: 2023"
+                        min="1900"
+                        max={new Date().getFullYear()}
+                        className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                      />
+                    </label>
+
+                    <label className="flex flex-col gap-2">
+                      <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">체중</span>
+                      <input
+                        type="text"
+                        value={weight}
+                        onChange={(e) => setWeight(e.target.value)}
+                        placeholder="예: 5.5kg"
+                        className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                      />
+                    </label>
+                  </div>
+
+                  <label className="flex flex-col gap-2">
+                    <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">색상</span>
+                    <input
+                      type="text"
+                      value={color}
+                      onChange={(e) => setColor(e.target.value)}
+                      placeholder="예: 갈색, 흰색"
+                      className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                    />
+                  </label>
+
+                  <label className="flex flex-col gap-2">
+                    <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">특이사항</span>
+                    <textarea
+                      value={specialMark}
+                      onChange={(e) => setSpecialMark(e.target.value)}
+                      placeholder="동물의 특징이나 특이사항을 입력해주세요."
+                      rows={3}
+                      className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all resize-y"
+                    />
+                  </label>
+                </div>
+
+                <div className="md:col-span-4 flex flex-col gap-2">
+                  <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">
+                    대표 이미지 <span className="text-red-500">*</span>
+                  </span>
+                  {imagePreview ? (
+                    <div className="relative flex-1 min-h-[240px]">
+                      <img
+                        src={imagePreview}
+                        alt="대표 이미지 미리보기"
+                        className="w-full h-full object-cover rounded-xl border border-[#e0e8e5] dark:border-[#2a453d]"
+                      />
+                      <button
+                        onClick={handleRemoveImage}
+                        className="absolute top-2 right-2 rounded-full bg-red-500 text-white p-2 hover:bg-red-600 transition-colors"
+                      >
+                        <span className="material-symbols-outlined text-sm">close</span>
+                      </button>
+                    </div>
+                  ) : (
+                    <label className="flex-1 min-h-[240px] border-2 border-dashed border-[#dbe6e3] dark:border-[#2a453d] rounded-xl bg-[#f8fbfb] dark:bg-[#122822] flex flex-col items-center justify-center gap-3 p-4 text-center cursor-pointer hover:border-primary hover:bg-primary/5 transition-colors group/upload">
+                      <div className="size-14 rounded-full bg-white dark:bg-[#1a2e29] shadow-sm flex items-center justify-center text-[#5f8c80] group-hover/upload:text-primary transition-colors border border-[#e0e8e5] dark:border-[#2a453d]">
+                        <span className="material-symbols-outlined text-[32px]">add_photo_alternate</span>
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <p className="text-sm font-bold text-[#111816] dark:text-white group-hover/upload:text-primary transition-colors">
+                          클릭하여 이미지 업로드
+                        </p>
+                        <p className="text-xs text-[#5f8c80]">SVG, PNG, JPG (최대 10MB)</p>
+                      </div>
+                      <input
+                        type="file"
+                        accept="image/jpeg,image/jpg,image/png,image/gif,image/webp"
+                        onChange={handleImageChange}
+                        className="hidden"
+                      />
+                    </label>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            <section className="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm border border-[#e0e8e5] dark:border-[#1f3530] overflow-hidden">
+              <div className="px-6 py-4 border-b border-[#f0f5f3] dark:border-[#1f3530] flex items-center gap-3 bg-[#fbfdfc] dark:bg-[#1a2e29]">
+                <div className="size-8 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold font-display">2</div>
+                <h2 className="text-[#111816] dark:text-white text-lg font-bold">발견 정보</h2>
+              </div>
+              <div className="p-6 grid grid-cols-1 md:grid-cols-12 gap-6">
+                <div className="md:col-span-8 flex flex-col gap-5">
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <label className="flex flex-col gap-2">
+                      <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">발견 일자</span>
+                      <input
+                        type="date"
+                        value={happenDate}
+                        onChange={(e) => setHappenDate(e.target.value)}
+                        className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                      />
+                    </label>
+
+                    <label className="flex flex-col gap-2">
+                      <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">발견 장소</span>
+                      <input
+                        type="text"
+                        value={happenPlace}
+                        onChange={(e) => setHappenPlace(e.target.value)}
+                        placeholder="예: 서울시 강남구 역삼동"
+                        className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                      />
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm border border-[#e0e8e5] dark:border-[#1f3530] overflow-hidden">
+              <div className="px-6 py-4 border-b border-[#f0f5f3] dark:border-[#1f3530] flex items-center gap-3 bg-[#fbfdfc] dark:bg-[#1a2e29]">
+                <div className="size-8 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold font-display">3</div>
+                <h2 className="text-[#111816] dark:text-white text-lg font-bold">공고 정보</h2>
+              </div>
+              <div className="p-6 grid grid-cols-1 md:grid-cols-12 gap-6">
+                <div className="md:col-span-8 flex flex-col gap-5">
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <label className="flex flex-col gap-2">
+                      <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">
+                        공고 시작일 <span className="text-red-500">*</span>
+                      </span>
+                      <input
+                        type="date"
+                        value={noticeStartDate}
+                        onChange={(e) => setNoticeStartDate(e.target.value)}
+                        className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                      />
+                    </label>
+
+                    <label className="flex flex-col gap-2">
+                      <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">
+                        공고 종료일 <span className="text-red-500">*</span>
+                      </span>
+                      <input
+                        type="date"
+                        value={noticeEndDate}
+                        onChange={(e) => setNoticeEndDate(e.target.value)}
+                        className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                      />
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm border border-[#e0e8e5] dark:border-[#1f3530] overflow-hidden">
+              <div className="px-6 py-4 border-b border-[#f0f5f3] dark:border-[#1f3530] flex items-center gap-3 bg-[#fbfdfc] dark:bg-[#1a2e29]">
+                <div className="size-8 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold font-display">4</div>
+                <h2 className="text-[#111816] dark:text-white text-lg font-bold">보호소 설명</h2>
+              </div>
+              <div className="p-6 grid grid-cols-1 md:grid-cols-12 gap-6">
+                <div className="md:col-span-8 flex flex-col gap-5">
+                  <label className="flex flex-col gap-2">
+                    <span className="text-[#111816] dark:text-gray-200 text-sm font-bold">상세 설명</span>
+                    <textarea
+                      value={description}
+                      onChange={(e) => setDescription(e.target.value)}
+                      placeholder="동물에 대한 상세한 설명을 입력해주세요."
+                      rows={6}
+                      className="w-full rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] bg-white dark:bg-[#0f231e] px-4 py-3 text-[#111816] dark:text-white placeholder-[#5f8c80] focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all resize-y"
+                    />
+                  </label>
+                </div>
+              </div>
+            </section>
+
+            <div className="flex justify-end gap-4 pt-6 border-t border-[#e0e8e5] dark:border-[#1f3530]">
+              <Link
+                to={`/animals/${id}`}
+                state={{ from: fromMyPage ? 'mypage' : undefined, tab: previousTab }}
+                className="px-4 py-2 text-sm font-bold text-[#5f8c80] bg-transparent border border-[#dbe6e3] rounded-lg hover:bg-white hover:text-primary dark:border-[#1f3530] dark:hover:bg-[#1f3530] transition-colors"
+              >
+                취소
+              </Link>
+              <button
+                onClick={handleSubmit}
+                disabled={updateAnimalMutation.isPending || uploadImageMutation.isPending}
+                className="px-4 py-2 text-sm font-bold text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {updateAnimalMutation.isPending || uploadImageMutation.isPending
+                  ? '수정 중...'
+                  : '수정하기'}
+              </button>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/Animals.tsx
+++ b/src/pages/Animals.tsx
@@ -114,6 +114,17 @@ export default function Animals() {
   const totalElements = data?.totalElements || 0;
   const totalPages = data?.totalPages || 0;
   const currentPage = data?.number || 0;
+  
+  // 실제로 표시되는 동물 중 "기다리고 있는" 동물만 카운트
+  // PROTECT(보호중), ADOPTION_PENDING(입양대기중) 상태만 카운트
+  const waitingAnimals = animals.filter(animal => 
+    animal.status === 'PROTECT' || animal.status === 'ADOPTION_PENDING'
+  );
+  
+  // 디버깅: totalElements 확인
+  console.log('Animals 페이지 - totalElements:', totalElements);
+  console.log('Animals 페이지 - 실제 표시되는 동물 수:', animals.length);
+  console.log('Animals 페이지 - 기다리는 동물 수:', waitingAnimals.length);
 
   return (
     <div className="min-h-screen bg-background-light dark:bg-background-dark font-display text-text-light dark:text-text-dark">
@@ -141,7 +152,13 @@ export default function Animals() {
             {/* 상단 바 (결과 수 + 뷰 토글 + 정렬) */}
             <div className="flex flex-col sm:flex-row justify-between items-center mb-6 gap-4">
               <p className="text-base text-gray-600 dark:text-gray-400">
-                총 {totalElements.toLocaleString()} 마리의 친구들이 기다리고 있어요
+                {animals.length > 0 ? (
+                  <>
+                    총 <span className="font-bold text-primary">{waitingAnimals.length.toLocaleString()}</span> 마리의 친구들이 기다리고 있어요
+                  </>
+                ) : (
+                  '동물 정보를 불러오는 중...'
+                )}
               </p>
 
               <div className="flex items-center gap-4">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,12 +3,21 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
 import { login } from '../api/auth.api';
 import { useAuthStore } from '../store/authStore';
+import Toast from '../components/common/Toast';
 
 export default function Login() {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error'; isVisible: boolean }>({
+    message: '',
+    type: 'success',
+    isVisible: false,
+  });
+  const [errorMessage, setErrorMessage] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
 
   const setAuth = useAuthStore((state) => state.setAuth);
 
@@ -24,16 +33,56 @@ export default function Login() {
         createdAt: new Date().toISOString(),
       };
       setAuth(user, data.accessToken, data.refreshToken);
-      alert('로그인 성공!');
+      // 로그인 성공 시 알림 없이 바로 이동
       navigate('/');
     },
     onError: (error: any) => {
-      alert(error.response?.data?.message || '로그인에 실패했습니다');
+      const message = error.response?.data?.message || '이메일 또는 비밀번호가 일치하지 않습니다.';
+      setErrorMessage(message);
+      setToast({
+        message,
+        type: 'error',
+        isVisible: true,
+      });
     },
   });
 
+  const validateEmail = (emailValue: string): boolean => {
+    if (!emailValue.trim()) {
+      setEmailError('이메일을 입력해주세요.');
+      return false;
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(emailValue)) {
+      setEmailError('올바른 이메일 형식을 입력해주세요.');
+      return false;
+    }
+    setEmailError('');
+    return true;
+  };
+
+  const validatePassword = (passwordValue: string): boolean => {
+    if (!passwordValue.trim()) {
+      setPasswordError('비밀번호를 입력해주세요.');
+      return false;
+    }
+    setPasswordError('');
+    return true;
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    setErrorMessage('');
+    setEmailError('');
+    setPasswordError('');
+    
+    const isEmailValid = validateEmail(email);
+    const isPasswordValid = validatePassword(password);
+    
+    if (!isEmailValid || !isPasswordValid) {
+      return;
+    }
+    
     loginMutation.mutate({ email, password });
   };
 
@@ -45,7 +94,21 @@ export default function Login() {
 
   return (
     <div className="relative flex min-h-screen w-full items-center justify-center p-4 bg-background-light dark:bg-background-dark">
-      <div className="flex h-full w-full max-w-5xl overflow-hidden rounded-xl bg-white dark:bg-gray-900 shadow-lg border border-gray-200 dark:border-gray-700">
+      <div className="w-full max-w-5xl flex flex-col gap-6">
+        {/* 로고 - 카드 바로 위 */}
+        <div className="flex justify-center">
+          <Link to="/" className="flex items-center gap-4 text-primary-content dark:text-white hover:opacity-80 transition-opacity">
+            <div className="text-primary text-2xl">
+              <span className="material-symbols-outlined">pets</span>
+            </div>
+            <h2 className="text-primary-content dark:text-white text-lg font-bold leading-tight tracking-[-0.015em]">
+              포우 브릿지
+            </h2>
+          </Link>
+        </div>
+
+        {/* 로그인 폼 카드 */}
+        <div className="flex h-full w-full overflow-hidden rounded-xl bg-white dark:bg-gray-900 shadow-lg border border-gray-200 dark:border-gray-700">
         {/* Left Side - Image & Welcome Message */}
         <div className="hidden lg:flex lg:w-1/2 flex-col items-center justify-center bg-emerald-200/50 dark:bg-gray-800 p-12">
           <div className="flex flex-col items-center text-center gap-6">
@@ -78,14 +141,30 @@ export default function Login() {
                     이메일
                   </p>
                   <input
-                    type="email"
+                    type="text"
                     value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    className="form-input w-full rounded-md text-gray-900 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-primary border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 h-12 placeholder:text-gray-500 dark:placeholder:text-gray-500 px-4 text-sm font-normal leading-normal"
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      // 입력 중일 때는 에러 메시지만 숨김 (입력값은 유지)
+                      if (emailError) {
+                        setEmailError('');
+                      }
+                      if (errorMessage) {
+                        setErrorMessage('');
+                      }
+                    }}
+                    className={`form-input w-full rounded-md text-gray-900 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-primary border ${
+                      emailError ? 'border-red-500 dark:border-red-500' : 'border-gray-300 dark:border-gray-600'
+                    } bg-white dark:bg-gray-700 h-12 placeholder:text-gray-500 dark:placeholder:text-gray-500 px-4 text-sm font-normal leading-normal`}
                     placeholder="이메일 주소를 입력하세요"
-                    required
                     disabled={loginMutation.isPending}
                   />
+                  {emailError && (
+                    <p className="text-red-500 dark:text-red-400 text-sm mt-1 flex items-center gap-1">
+                      <span className="material-symbols-outlined text-base">error</span>
+                      {emailError}
+                    </p>
+                  )}
                 </label>
 
                 {/* Password Input */}
@@ -97,10 +176,20 @@ export default function Login() {
                     <input
                       type={showPassword ? 'text' : 'password'}
                       value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      className="form-input w-full h-full rounded-md text-gray-900 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-primary border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 placeholder:text-gray-500 dark:placeholder:text-gray-500 px-4 pr-10 text-sm font-normal leading-normal"
+                      onChange={(e) => {
+                        setPassword(e.target.value);
+                        // 입력 중일 때는 에러 메시지만 숨김 (입력값은 유지)
+                        if (passwordError) {
+                          setPasswordError('');
+                        }
+                        if (errorMessage) {
+                          setErrorMessage('');
+                        }
+                      }}
+                      className={`form-input w-full h-full rounded-md text-gray-900 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-primary border ${
+                        passwordError || errorMessage ? 'border-red-500 dark:border-red-500' : 'border-gray-300 dark:border-gray-600'
+                      } bg-white dark:bg-gray-700 placeholder:text-gray-500 dark:placeholder:text-gray-500 px-4 pr-10 text-sm font-normal leading-normal`}
                       placeholder="비밀번호를 입력하세요"
-                      required
                       disabled={loginMutation.isPending}
                     />
                     <button
@@ -114,6 +203,12 @@ export default function Login() {
                       </span>
                     </button>
                   </div>
+                  {(passwordError || errorMessage) && (
+                    <p className="text-red-500 dark:text-red-400 text-sm mt-1 flex items-center gap-1">
+                      <span className="material-symbols-outlined text-base">error</span>
+                      {errorMessage || passwordError}
+                    </p>
+                  )}
                 </label>
               </div>
 
@@ -179,7 +274,17 @@ export default function Login() {
             </form>
           </div>
         </div>
+        </div>
       </div>
+
+      {/* Toast 알림 */}
+      <Toast
+        message={toast.message}
+        type={toast.type}
+        isVisible={toast.isVisible}
+        onClose={() => setToast({ ...toast, isVisible: false })}
+        duration={4000}
+      />
     </div>
   );
 }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { getMyInfo, updateNickname, updatePassword, getFavoriteAnimals, getRegisteredAnimals } from '../api/user.api';
 import { getWishlists, deleteWishlist, addToCart, getCart, clearCart } from '../api/products.api';
 import { getOrders } from '../api/orders.api';
@@ -14,11 +14,43 @@ type TabType = 'profile' | 'password' | 'favoriteAnimals' | 'registeredAnimals' 
 
 export default function MyPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const { logout } = useAuthStore();
   const user = useAuthStore((state) => state.user);
 
-  const [activeTab, setActiveTab] = useState<TabType>('profile');
+  // location.state에서 탭 정보 가져오기 (뒤로가기 시)
+  // sessionStorage도 확인하여 뒤로가기 시에도 탭 유지
+  const [activeTab, setActiveTab] = useState<TabType>(() => {
+    // 1. location.state에서 우선 확인
+    if (location.state?.tab) {
+      return location.state.tab as TabType;
+    }
+    // 2. sessionStorage에서 확인 (뒤로가기 시)
+    const savedTab = sessionStorage.getItem('mypageActiveTab');
+    if (savedTab && ['profile', 'password', 'favoriteAnimals', 'registeredAnimals', 'wishlist', 'cart', 'orders'].includes(savedTab)) {
+      return savedTab as TabType;
+    }
+    // 3. 기본값
+    return 'profile';
+  });
+
+  // location.state가 변경되면 탭 업데이트
+  useEffect(() => {
+    if (location.state?.tab) {
+      const tab = location.state.tab as TabType;
+      setActiveTab(tab);
+      // sessionStorage에 저장 (뒤로가기 대비)
+      sessionStorage.setItem('mypageActiveTab', tab);
+      // state 초기화 (뒤로가기 시 중복 적용 방지)
+      window.history.replaceState({}, '');
+    }
+  }, [location.state]);
+
+  // activeTab이 변경되면 sessionStorage에 저장
+  useEffect(() => {
+    sessionStorage.setItem('mypageActiveTab', activeTab);
+  }, [activeTab]);
   const [nicknameInput, setNicknameInput] = useState('');
   const [passwordData, setPasswordData] = useState<PasswordUpdateRequest>({
     currentPassword: '',
@@ -60,6 +92,18 @@ export default function MyPage() {
     queryFn: () => getRegisteredAnimals(registeredPage, 20),
     enabled: activeTab === 'registeredAnimals' && userInfo?.role === 'ROLE_SHELTER',
   });
+
+  // 디버깅: 등록한 동물 목록 확인
+  useEffect(() => {
+    if (registeredAnimals) {
+      console.log('=== 등록한 동물 목록 응답 ===');
+      console.log('전체 응답:', registeredAnimals);
+      console.log('전체 개수:', registeredAnimals.content?.length || 0);
+      console.log('각 동물의 apiSource:', registeredAnimals.content?.map((a) => ({ id: a.id, apiSource: a.apiSource, breed: a.breed })));
+      const manualAnimals = registeredAnimals.content?.filter((animal) => animal.apiSource === 'MANUAL') || [];
+      console.log('MANUAL 필터링 후 개수:', manualAnimals.length);
+    }
+  }, [registeredAnimals]);
 
   // 위시리스트 조회
   const { data: wishlists } = useQuery({
@@ -893,81 +937,161 @@ export default function MyPage() {
 
               {activeTab === 'registeredAnimals' && (
                 <>
-                  <h2 className="text-text-main dark:text-white text-[22px] font-bold leading-tight tracking-[-0.015em] pb-6 border-b border-gray-200 dark:border-gray-700">
-                    내 보호소가 등록한 동물
-                  </h2>
+                  <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 pb-6 border-b border-gray-200 dark:border-gray-700">
+                    <h2 className="text-text-main dark:text-white text-[22px] font-bold leading-tight tracking-[-0.015em]">
+                      내 보호소가 등록한 동물
+                    </h2>
+                    <Link
+                      to="/animals/new"
+                      className="flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors font-bold text-sm"
+                    >
+                      <span className="material-symbols-outlined text-[18px]">add</span>
+                      새 동물 등록
+                    </Link>
+                  </div>
 
-                  {registeredAnimals && registeredAnimals.content.length > 0 ? (
-                    <div className="mt-8">
-                      <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-                        총 {registeredAnimals.totalElements}마리의 동물을 등록했습니다
-                      </p>
-                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {registeredAnimals.content.map((animal) => (
-                          <Link
-                            key={animal.id}
-                            to={`/animals/${animal.id}`}
-                            className="block bg-gray-50 dark:bg-gray-800 rounded-xl overflow-hidden hover:shadow-lg transition-shadow border border-gray-200 dark:border-gray-700"
-                          >
-                            {animal.imageUrl ? (
-                              <img src={animal.imageUrl} alt={animal.breed || '동물'} className="w-full h-48 object-cover" />
-                            ) : (
-                              <div className="w-full h-48 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-                                <span className="material-symbols-outlined text-5xl text-gray-400">pets</span>
-                              </div>
-                            )}
-                            <div className="p-4">
-                              <h3 className="font-bold text-text-main dark:text-white mb-2">{animal.breed || '품종 정보 없음'}</h3>
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
-                                {animal.species || '종 정보 없음'} • {animal.gender || '성별 정보 없음'} • {animal.age ? `${animal.age}세` : '나이 정보 없음'}
-                              </p>
-                              {animal.status && (
-                                <span className={`inline-block mt-2 px-2 py-1 text-xs rounded ${
-                                  animal.status === 'PROTECT' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-700'
-                                }`}>
-                                  {animal.status === 'PROTECT' ? '보호중' : animal.status}
-                                </span>
-                              )}
-                            </div>
-                          </Link>
-                        ))}
-                      </div>
-
-                      {/* 페이지네이션 */}
-                      {registeredAnimals && registeredAnimals.totalPages > 1 && (
-                        <div className="flex items-center justify-center gap-2 mt-8">
-                          <button
-                            onClick={() => setRegisteredPage((prev) => Math.max(0, prev - 1))}
-                            disabled={registeredPage === 0}
-                            className="px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-                          >
-                            이전
-                          </button>
-                          <div className="flex items-center gap-1">
-                            {Array.from({ length: registeredAnimals.totalPages }, (_, i) => i).map((page) => (
-                              <button
-                                key={page}
-                                onClick={() => setRegisteredPage(page)}
-                                className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                                  registeredPage === page
-                                    ? 'bg-primary text-white'
-                                    : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
-                                }`}
+                  {registeredAnimals && registeredAnimals.content && registeredAnimals.content.length > 0 ? (
+                    (() => {
+                      // apiSource 필드가 없을 경우 apmsNoticeNo로 판단
+                      // MAN-으로 시작하면 수동 등록, 그 외는 APMS 동기화
+                      const manualAnimals = registeredAnimals.content.filter((animal) => {
+                        // apiSource가 있으면 그것을 우선 사용
+                        if (animal.apiSource) {
+                          return animal.apiSource === 'MANUAL';
+                        }
+                        // apiSource가 없으면 apmsNoticeNo로 판단
+                        return animal.apmsNoticeNo && animal.apmsNoticeNo.startsWith('MAN-');
+                      });
+                      console.log('MyPage - 필터링 전:', registeredAnimals.content.length, '개');
+                      console.log('MyPage - 필터링 후:', manualAnimals.length, '개');
+                      return manualAnimals.length > 0 ? (
+                        <div className="mt-8">
+                          <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+                            총 {manualAnimals.length}마리의 동물을 등록했습니다
+                          </p>
+                          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                            {manualAnimals.map((animal) => (
+                              <Link
+                                key={animal.id}
+                                to={`/animals/${animal.id}`}
+                                state={{ from: 'mypage', tab: 'registeredAnimals' }}
+                                className="block bg-gray-50 dark:bg-gray-800 rounded-xl overflow-hidden hover:shadow-lg transition-shadow border border-gray-200 dark:border-gray-700"
                               >
-                                {page + 1}
-                              </button>
+                                {animal.imageUrl ? (
+                                  <img src={animal.imageUrl} alt={animal.breed || '동물'} className="w-full h-48 object-cover" />
+                                ) : (
+                                  <div className="w-full h-48 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                                    <span className="material-symbols-outlined text-5xl text-gray-400">pets</span>
+                                  </div>
+                                )}
+                                <div className="p-4">
+                                  {/* 상태 + 성별 + 중성화 배지 */}
+                                  <div className="flex items-center gap-2 mb-2 flex-wrap">
+                                    {animal.status && (
+                                      <span className={`text-xs font-bold rounded-full px-2 py-1 ${
+                                        animal.status === 'PROTECT' 
+                                          ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' 
+                                          : 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400'
+                                      }`}>
+                                        {animal.status === 'PROTECT' ? '보호중' : animal.status}
+                                      </span>
+                                    )}
+                                    {animal.gender === 'MALE' && (
+                                      <span className="text-xs font-bold rounded-full px-2 py-1 bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+                                        수컷
+                                      </span>
+                                    )}
+                                    {animal.gender === 'FEMALE' && (
+                                      <span className="text-xs font-bold rounded-full px-2 py-1 bg-pink-100 text-pink-800 dark:bg-pink-900/30 dark:text-pink-400">
+                                        암컷
+                                      </span>
+                                    )}
+                                    {(!animal.gender || (animal.gender as string) === 'UNKNOWN') && (
+                                      <span className="text-xs font-bold rounded-full px-2 py-1 bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                                        미상
+                                      </span>
+                                    )}
+                                    {(animal.neuterStatus === 'YES' || animal.neutered === true) && (
+                                      <span className="text-xs font-bold rounded-full px-2 py-1 bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400">
+                                        중성화 완료
+                                      </span>
+                                    )}
+                                    {(animal.neuterStatus === 'NO' || animal.neutered === false) && (
+                                      <span className="text-xs font-bold rounded-full px-2 py-1 bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                                        중성화 미완료
+                                      </span>
+                                    )}
+                                    {animal.neuterStatus === 'UNKNOWN' && (
+                                      <span className="text-xs font-bold rounded-full px-2 py-1 bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                                        중성화 미상
+                                      </span>
+                                    )}
+                                  </div>
+                                  
+                                  <h3 className="font-bold text-text-main dark:text-white mb-2">{animal.breed || '품종 정보 없음'}</h3>
+                                  <p className="text-sm text-gray-600 dark:text-gray-400">
+                                    {animal.species || '종 정보 없음'} • {animal.age ? `${animal.age}세` : '나이 정보 없음'}
+                                  </p>
+                                </div>
+                              </Link>
                             ))}
                           </div>
-                          <button
-                            onClick={() => setRegisteredPage((prev) => Math.min(registeredAnimals.totalPages - 1, prev + 1))}
-                            disabled={registeredPage >= registeredAnimals.totalPages - 1}
-                            className="px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-                          >
-                            다음
-                          </button>
+
+                          {/* 페이지네이션 */}
+                          {(() => {
+                            // 필터링 후 실제 동물 수를 기준으로 페이지 수 계산
+                            const pageSize = 20;
+                            const actualTotalPages = Math.ceil(manualAnimals.length / pageSize);
+                            
+                            return actualTotalPages > 1 ? (
+                              <div className="flex items-center justify-center gap-2 mt-8">
+                                <button
+                                  onClick={() => setRegisteredPage((prev) => Math.max(0, prev - 1))}
+                                  disabled={registeredPage === 0}
+                                  className="px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                                >
+                                  이전
+                                </button>
+                                <div className="flex items-center gap-1">
+                                  {Array.from({ length: actualTotalPages }, (_, i) => i).map((page) => (
+                                    <button
+                                      key={page}
+                                      onClick={() => setRegisteredPage(page)}
+                                      className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                                        registeredPage === page
+                                          ? 'bg-primary text-white'
+                                          : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                                      }`}
+                                    >
+                                      {page + 1}
+                                    </button>
+                                  ))}
+                                </div>
+                                <button
+                                  onClick={() => setRegisteredPage((prev) => Math.min(actualTotalPages - 1, prev + 1))}
+                                  disabled={registeredPage >= actualTotalPages - 1}
+                                  className="px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                                >
+                                  다음
+                                </button>
+                              </div>
+                            ) : null;
+                          })()}
                         </div>
-                      )}
-                    </div>
+                      ) : (
+                        <div className="flex flex-col items-center justify-center py-20 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 mt-8">
+                          <span className="material-symbols-outlined text-7xl text-gray-300 dark:text-gray-600 mb-4">
+                            pets
+                          </span>
+                          <h3 className="text-xl font-bold text-text-main dark:text-white mb-2">
+                            아직 등록한 동물이 없습니다
+                          </h3>
+                          <p className="text-gray-500 dark:text-gray-400 mb-6">
+                            보호소 계정으로 동물을 등록해보세요
+                          </p>
+                        </div>
+                      );
+                    })()
                   ) : (
                     <div className="mt-8 text-center py-12 bg-gray-50 dark:bg-gray-800 rounded-lg">
                       <span className="material-symbols-outlined text-6xl text-gray-300 dark:text-gray-600 mb-3">pets</span>

--- a/src/pages/ProductCreate.tsx
+++ b/src/pages/ProductCreate.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { createProduct, getOptionGroups, getCategories, uploadImage } from '../api/products.api';
 import type { OptionGroupResponse, CategoryResponse } from '../types/api.types';
+import AdminSidebar from '../components/layout/AdminSidebar';
+import { useAuthStore } from '../store/authStore';
 
 // SKU 생성용 타입
 interface CreateSku {
@@ -11,7 +13,6 @@ interface CreateSku {
   stockQuantity: number;
   optionValueIds: number[];
 }
-import { useAuthStore } from '../store/authStore';
 import CustomSelect from '../components/common/CustomSelect';
 
 // 선택된 옵션 값으로부터 SKU 조합 생성
@@ -258,7 +259,7 @@ export default function ProductCreate() {
     mutationFn: createProduct,
     onSuccess: () => {
       alert('상품이 등록되었습니다.');
-      navigate('/products');
+      navigate('/admin/products');
     },
     onError: (error: any) => {
       const message = error.response?.data?.message || '상품 등록에 실패했습니다.';
@@ -347,148 +348,60 @@ export default function ProductCreate() {
     return parts.join(', ');
   };
 
-  const user = useAuthStore((state) => state.user);
-  const clearAuth = useAuthStore((state) => state.clearAuth);
-
-  const handleLogout = () => {
-    clearAuth();
-    navigate('/login');
-  };
+  const { user } = useAuthStore();
 
   return (
-    <div className="bg-background-light dark:bg-background-dark text-[#111816] dark:text-gray-100 font-body h-screen flex overflow-hidden">
+    <div className="bg-background-light dark:bg-background-dark text-text-main dark:text-white h-screen overflow-hidden flex">
       {/* 사이드바 */}
-      <aside className="w-64 bg-surface-light dark:bg-surface-dark border-r border-[#e0e8e5] dark:border-[#1f3530] flex flex-col flex-shrink-0 z-50">
-        {/* 로고 */}
-        <div className="h-16 flex items-center gap-3 px-6 border-b border-[#e0e8e5] dark:border-[#1f3530]">
-          <div className="size-8 text-primary">
-            <svg className="w-full h-full" fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
-              <g clipPath="url(#clip0_6_330)">
-                <path clipRule="evenodd" d="M24 0.757355L47.2426 24L24 47.2426L0.757355 24L24 0.757355ZM21 35.7574V12.2426L9.24264 24L21 35.7574Z" fill="currentColor" fillRule="evenodd"></path>
-              </g>
-              <defs>
-                <clipPath id="clip0_6_330"><rect fill="white" height="48" width="48"></rect></clipPath>
-              </defs>
-            </svg>
-          </div>
-          <h1 className="text-xl font-display font-bold tracking-tight text-[#111816] dark:text-white">PawBridge</h1>
-        </div>
-        
-        {/* 네비게이션 */}
-        <nav className="flex-1 overflow-y-auto py-6 px-3 flex flex-col gap-1 scrollbar-hide">
-          <Link to="/admin/dashboard" className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[#5f8c80] hover:text-[#111816] hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] dark:hover:text-white transition-colors">
-            <span className="material-symbols-outlined text-[22px]">dashboard</span>
-            <span className="text-sm font-medium">대시보드</span>
-          </Link>
-          <Link to="/admin/stats" className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[#5f8c80] hover:text-[#111816] hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] dark:hover:text-white transition-colors">
-            <span className="material-symbols-outlined text-[22px]">bar_chart</span>
-            <span className="text-sm font-medium">통계</span>
-          </Link>
-          <div className="my-2 h-px bg-[#e0e8e5] dark:bg-[#1f3530] mx-3"></div>
-          <Link to="/admin/users" className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[#5f8c80] hover:text-[#111816] hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] dark:hover:text-white transition-colors">
-            <span className="material-symbols-outlined text-[22px]">group</span>
-            <span className="text-sm font-medium">회원 관리</span>
-          </Link>
-          <Link to="/admin/posts" className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[#5f8c80] hover:text-[#111816] hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] dark:hover:text-white transition-colors">
-            <span className="material-symbols-outlined text-[22px]">article</span>
-            <span className="text-sm font-medium">게시글 관리</span>
-          </Link>
-          <Link to="/admin/categories" className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[#5f8c80] hover:text-[#111816] hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] dark:hover:text-white transition-colors">
-            <span className="material-symbols-outlined text-[22px]">category</span>
-            <span className="text-sm font-medium">카테고리 관리</span>
-          </Link>
-          <div className="flex flex-col gap-1 mt-1">
-            <div className="flex items-center justify-between px-3 py-2.5 rounded-lg text-[#111816] dark:text-white bg-[#f0f5f3] dark:bg-[#1f3530] font-bold">
-              <div className="flex items-center gap-3">
-                <span className="material-symbols-outlined text-[22px] text-primary">inventory_2</span>
-                <span className="text-sm">상품 관리</span>
-              </div>
-              <span className="material-symbols-outlined text-[18px]">expand_less</span>
-            </div>
-            <div className="flex flex-col pl-11 gap-1">
-              <Link to="/products" className="block px-3 py-2 rounded-lg text-sm text-[#5f8c80] hover:text-[#111816] hover:bg-[#f0f5f3] dark:hover:text-white dark:hover:bg-[#1f3530] transition-colors">
-                상품 목록
-              </Link>
-              <Link to="/products/new" className="block px-3 py-2 rounded-lg text-sm font-bold text-primary bg-primary/10 transition-colors">
-                상품 등록
-              </Link>
-            </div>
-          </div>
-          <div className="flex flex-col gap-1 mt-1">
-            <button className="w-full flex items-center justify-between px-3 py-2.5 rounded-lg text-[#5f8c80] hover:text-[#111816] hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] dark:hover:text-white transition-colors group">
-              <div className="flex items-center gap-3">
-                <span className="material-symbols-outlined text-[22px] group-hover:text-primary transition-colors">tune</span>
-                <span className="text-sm font-medium">옵션 관리</span>
-              </div>
-              <span className="material-symbols-outlined text-[18px]">expand_more</span>
-            </button>
-          </div>
-        </nav>
-        
-        {/* 하단 고객지원 */}
-        <div className="p-4 border-t border-[#e0e8e5] dark:border-[#1f3530]">
-          <button className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-bold text-[#5f8c80] hover:text-[#111816] dark:hover:text-white bg-transparent hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] rounded-lg transition-colors">
-            <span className="material-symbols-outlined text-[18px]">help</span>
-            고객지원
-          </button>
-        </div>
-      </aside>
+      <AdminSidebar />
 
-      {/* 메인 컨텐츠 영역 */}
-      <div className="flex-1 flex flex-col h-full overflow-hidden relative">
-        {/* 상단 헤더 */}
-        <header className="flex items-center justify-end h-16 px-8 border-b border-[#e0e8e5] dark:border-[#1f3530] bg-surface-light dark:bg-surface-dark flex-shrink-0">
+      {/* 메인 콘텐츠 */}
+      <main className="flex-1 flex flex-col min-w-0 h-full overflow-hidden bg-background-light dark:bg-background-dark relative">
+        {/* 헤더 */}
+        <header className="flex-none h-16 bg-surface-light dark:bg-surface-dark border-b border-[#e5e7eb] dark:border-gray-700 px-8 flex items-center justify-between z-10">
+          <div className="flex items-center gap-4">
+            <h2 className="text-xl font-bold text-text-main dark:text-white">상품 등록</h2>
+          </div>
           <div className="flex items-center gap-6">
-            <button className="relative flex items-center gap-2 text-[#5f8c80] hover:text-primary transition-colors">
-              <span className="material-symbols-outlined text-[24px]">notifications</span>
-              <span className="absolute top-0 right-0 size-2.5 bg-red-500 rounded-full border-2 border-surface-light dark:border-surface-dark"></span>
-            </button>
-            <div className="h-6 w-px bg-[#e0e8e5] dark:border-[#1f3530]"></div>
-            <div className="flex items-center gap-3">
-              <div className="bg-center bg-no-repeat bg-cover rounded-full size-9 ring-2 ring-primary/20 bg-primary/20 flex items-center justify-center">
-                <span className="material-symbols-outlined text-primary">person</span>
-              </div>
-              <div className="hidden md:flex flex-col text-right">
-                <span className="text-sm font-bold leading-none text-[#111816] dark:text-white">{user?.name || '관리자'}</span>
-                <span className="text-xs text-[#5f8c80]">{user?.role === 'ROLE_ADMIN' ? 'Admin' : 'User'}</span>
-              </div>
+            <div className="hidden md:flex items-center w-64 h-10 rounded-lg bg-background-light dark:bg-gray-800 px-3 border border-transparent focus-within:border-primary transition-colors">
+              <span className="material-symbols-outlined text-text-secondary">search</span>
+              <input
+                className="bg-transparent border-none outline-none text-sm ml-2 w-full text-text-main dark:text-white placeholder:text-text-secondary focus:ring-0"
+                placeholder="검색..."
+                type="text"
+              />
             </div>
-            <button 
-              onClick={handleLogout}
-              className="flex items-center justify-center size-9 rounded-lg hover:bg-[#f0f5f3] dark:hover:bg-[#1f3530] text-[#5f8c80] hover:text-red-500 transition-colors ml-2"
-            >
-              <span className="material-symbols-outlined text-[20px]">logout</span>
-            </button>
+            <div className="flex items-center gap-3">
+              <button className="size-10 rounded-full flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 text-text-main dark:text-white transition-colors relative">
+                <span className="material-symbols-outlined">notifications</span>
+                <span className="absolute top-2 right-2 size-2 bg-red-500 rounded-full border border-white dark:border-gray-800"></span>
+              </button>
+              <button className="flex items-center gap-2 pl-1 pr-3 py-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                <div
+                  className="size-8 rounded-full bg-cover bg-center border border-gray-200 bg-primary/20 flex items-center justify-center"
+                >
+                  <div className="w-full h-full flex items-center justify-center text-text-main font-bold text-xs">
+                    {user?.name?.charAt(0) || '관'}
+                  </div>
+                </div>
+                <span className="text-sm font-semibold text-text-main dark:text-white hidden lg:block">
+                  {user?.name || '관리자'}님
+                </span>
+              </button>
+            </div>
           </div>
         </header>
 
-        {/* 메인 컨텐츠 */}
-        <main className="flex-1 overflow-y-auto bg-background-light dark:bg-background-dark p-6 md:p-10 pb-24">
-        <div className="max-w-5xl mx-auto flex flex-col gap-6">
-          {/* 브레드크럼 */}
-          <nav className="flex flex-wrap gap-2 text-sm font-medium">
-            <a className="text-[#5f8c80] hover:text-primary transition-colors" href="/">
-              홈
-            </a>
-            <span className="text-[#5f8c80] material-symbols-outlined text-[16px] pt-0.5">chevron_right</span>
-            <a className="text-[#5f8c80] hover:text-primary transition-colors" href="/products">
-              상품 관리
-            </a>
-            <span className="text-[#5f8c80] material-symbols-outlined text-[16px] pt-0.5">chevron_right</span>
-            <span className="text-[#111816] dark:text-white font-bold">상품 등록</span>
-          </nav>
+        {/* 콘텐츠 영역 */}
+        <div className="flex-1 overflow-y-auto p-8 bg-background-light dark:bg-background-dark">
+          <div className="max-w-5xl mx-auto flex flex-col gap-6">
+            <div className="mb-4">
+              <p className="text-text-secondary dark:text-gray-400 text-sm">
+                새로운 유기동물 후원 굿즈 상품을 등록하고 재고를 관리하세요.
+              </p>
+            </div>
 
-          {/* 페이지 제목 */}
-          <div className="flex flex-col gap-2 pb-2">
-            <h1 className="text-[#111816] dark:text-white text-3xl font-display font-black leading-tight tracking-tight">
-              상품 등록
-            </h1>
-            <p className="text-[#5f8c80] text-base font-normal">
-              새로운 유기동물 후원 굿즈 상품을 등록하고 재고를 관리하세요.
-            </p>
-          </div>
-
-          {/* 기본 정보 섹션 */}
+            {/* 기본 정보 섹션 */}
           <section className="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm border border-[#e0e8e5] dark:border-[#1f3530] overflow-hidden">
             <div className="px-6 py-4 border-b border-[#f0f5f3] dark:border-[#1f3530] flex items-center gap-3 bg-[#fbfdfc] dark:bg-[#1a2e29]">
               <div className="size-8 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold font-display">1</div>
@@ -726,35 +639,35 @@ export default function ProductCreate() {
               </table>
             </div>
           </section>
+
+          {/* 하단 고정 버튼 */}
+          <footer className="sticky bottom-0 bg-white dark:bg-[#0f231e] border-t border-[#e0e8e5] dark:border-[#1f3530] px-6 md:px-10 py-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] z-40 -mx-8 -mb-8 mt-8">
+            <div className="max-w-5xl mx-auto flex justify-between items-center">
+              <p className="text-sm text-[#5f8c80] hidden md:flex items-center gap-2">
+                <span className="material-symbols-outlined text-[18px]">info</span>
+                <span><span className="font-bold">Tip:</span> 필수 항목(*)을 모두 입력해야 상품 등록이 가능합니다.</span>
+              </p>
+              <div className="flex gap-4 w-full md:w-auto justify-end">
+                <button
+                  onClick={handleSubmit}
+                  disabled={createProductMutation.isPending || uploadImageMutation.isPending}
+                  className="px-8 py-2.5 rounded-lg bg-primary hover:bg-primary-dark text-[#111816] font-bold shadow-lg shadow-primary/25 transition-colors flex items-center justify-center gap-2 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <span className="material-symbols-outlined text-[20px]">check</span>
+                  {createProductMutation.isPending || uploadImageMutation.isPending ? '등록 중...' : '상품 등록하기'}
+                </button>
+                <button
+                  onClick={() => navigate('/admin/products')}
+                  className="px-6 py-2.5 rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] text-[#111816] dark:text-gray-300 font-bold hover:bg-[#f0f5f3] dark:hover:bg-[#1a2e29] transition-colors w-full md:w-auto"
+                >
+                  취소하기
+                </button>
+              </div>
+            </div>
+          </footer>
+          </div>
         </div>
       </main>
-
-      {/* 하단 고정 버튼 */}
-        <footer className="absolute bottom-0 left-0 w-full bg-white dark:bg-[#0f231e] border-t border-[#e0e8e5] dark:border-[#1f3530] px-6 md:px-10 py-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] z-40">
-          <div className="max-w-5xl mx-auto flex justify-between items-center">
-            <p className="text-sm text-[#5f8c80] hidden md:flex items-center gap-2">
-              <span className="material-symbols-outlined text-[18px]">info</span>
-              <span><span className="font-bold">Tip:</span> 필수 항목(*)을 모두 입력해야 상품 등록이 가능합니다.</span>
-            </p>
-            <div className="flex gap-4 w-full md:w-auto justify-end">
-              <button
-                onClick={handleSubmit}
-                disabled={createProductMutation.isPending || uploadImageMutation.isPending}
-                className="px-8 py-2.5 rounded-lg bg-primary hover:bg-primary-dark text-[#111816] font-bold shadow-lg shadow-primary/25 transition-colors flex items-center justify-center gap-2 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <span className="material-symbols-outlined text-[20px]">check</span>
-                {createProductMutation.isPending || uploadImageMutation.isPending ? '등록 중...' : '상품 등록하기'}
-              </button>
-              <button
-                onClick={() => navigate('/products')}
-                className="px-6 py-2.5 rounded-lg border border-[#dbe6e3] dark:border-[#2a453d] text-[#111816] dark:text-gray-300 font-bold hover:bg-[#f0f5f3] dark:hover:bg-[#1a2e29] transition-colors w-full md:w-auto"
-              >
-                취소하기
-              </button>
-            </div>
-          </div>
-        </footer>
-      </div>
     </div>
   );
 }

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,20 +1,11 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getProducts, addToCart } from '../api/products.api';
-import type { ProductSearchParams } from '../types/api.types';
+import { getProducts, addToCart, getCategories } from '../api/products.api';
+import type { ProductSearchParams, CategoryResponse } from '../types/api.types';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
 import ProductFilterSidebar from '../components/common/ProductFilterSidebar';
 import ProductCard from '../components/common/ProductCard';
-
-// 카테고리 이름 매핑
-const categoryNames: Record<number, string> = {
-  1: '사료 및 간식',
-  2: '장난감',
-  3: '위생/미용 용품',
-  4: '의류/액세서리',
-  5: '굿즈',
-};
 
 export default function Products() {
   const queryClient = useQueryClient();
@@ -25,6 +16,12 @@ export default function Products() {
     size: 12,
     sortBy: 'createdAt',
     sortOrder: 'desc',
+  });
+
+  // 카테고리 목록 조회
+  const { data: categories = [] } = useQuery<CategoryResponse[]>({
+    queryKey: ['categories'],
+    queryFn: getCategories,
   });
 
   // 상품 목록 조회
@@ -82,9 +79,8 @@ export default function Products() {
   };
 
   // 현재 카테고리 이름
-  const currentCategoryName = filters.categoryId 
-    ? categoryNames[filters.categoryId] 
-    : '전체 상품';
+  const currentCategory = categories.find(cat => cat.id === filters.categoryId);
+  const currentCategoryName = currentCategory?.name || '전체 상품';
 
   // 로딩 상태
   if (isLoading) {

--- a/src/pages/RegisteredAnimals.tsx
+++ b/src/pages/RegisteredAnimals.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getRegisteredAnimals } from '../api/user.api';
@@ -15,6 +15,18 @@ export default function RegisteredAnimals() {
     queryFn: () => getRegisteredAnimals(currentPage, pageSize),
   });
 
+  // 디버깅: 등록한 동물 목록 확인
+  useEffect(() => {
+    if (data) {
+      console.log('=== RegisteredAnimals 페이지 응답 ===');
+      console.log('전체 응답:', data);
+      console.log('전체 개수:', data.content?.length || 0);
+      console.log('각 동물의 apiSource:', data.content?.map((a) => ({ id: a.id, apiSource: a.apiSource, breed: a.breed })));
+      const manualAnimals = data.content?.filter((animal) => animal.apiSource === 'MANUAL') || [];
+      console.log('MANUAL 필터링 후 개수:', manualAnimals.length);
+    }
+  }, [data]);
+
   const handlePageChange = (newPage: number) => {
     setCurrentPage(newPage);
     window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -28,9 +40,38 @@ export default function RegisteredAnimals() {
     );
   }
 
-  const totalPages = data?.totalPages || 0;
-  const totalElements = data?.totalElements || 0;
-  const animals = data?.content || [];
+  // 서버가 MANUAL만 반환하는지 확인 필요
+  // 현재는 프론트엔드에서 필터링 (서버가 모든 동물을 반환하는 경우 대비)
+  const allAnimals = data?.content || [];
+  // apiSource 필드가 없을 경우 apmsNoticeNo로 판단
+  // MAN-으로 시작하면 수동 등록, 그 외는 APMS 동기화
+  const animals = allAnimals.filter((animal) => {
+    // apiSource가 있으면 그것을 우선 사용
+    if (animal.apiSource) {
+      return animal.apiSource === 'MANUAL';
+    }
+    // apiSource가 없으면 apmsNoticeNo로 판단
+    return animal.apmsNoticeNo && animal.apmsNoticeNo.startsWith('MAN-');
+  });
+  const manualCount = animals.length;
+  
+  console.log('RegisteredAnimals - 필터링 전:', allAnimals.length, '개');
+  console.log('RegisteredAnimals - 필터링 후:', animals.length, '개');
+  console.log('RegisteredAnimals - 각 동물 정보:', allAnimals.map((a) => ({ 
+    id: a.id, 
+    apiSource: a.apiSource, 
+    apmsNoticeNo: a.apmsNoticeNo,
+    isManual: a.apiSource === 'MANUAL' || (a.apmsNoticeNo && a.apmsNoticeNo.startsWith('MAN-'))
+  })));
+  
+  // 필터링된 결과를 기준으로 페이지네이션 계산
+  // 실제 표시되는 동물 수를 기준으로 페이지 수 계산
+  const actualTotalPages = Math.ceil(manualCount / pageSize);
+  
+  // 디버깅
+  console.log('RegisteredAnimals - 필터링 후 동물 수:', manualCount);
+  console.log('RegisteredAnimals - 계산된 totalPages:', actualTotalPages);
+  console.log('RegisteredAnimals - 서버 totalPages:', data?.totalPages);
 
   return (
     <div className="flex flex-col min-h-screen bg-background-light dark:bg-background-dark">
@@ -42,7 +83,7 @@ export default function RegisteredAnimals() {
             내 보호소가 등록한 동물
           </h1>
           <p className="text-subtext-light dark:text-gray-400 text-base">
-            총 {totalElements}마리의 동물을 등록했습니다
+            총 {manualCount}마리의 동물을 등록했습니다
           </p>
         </div>
 
@@ -63,9 +104,9 @@ export default function RegisteredAnimals() {
                         alt={animal.breed || '동물'}
                         className="w-full h-full object-cover"
                       />
-                      {/* 상태 뱃지 */}
-                      {animal.status && (
-                        <div className="absolute top-3 right-3">
+                      {/* 상태 + 성별 + 중성화 배지 */}
+                      <div className="absolute top-3 right-3 flex items-center gap-2 flex-wrap justify-end">
+                        {animal.status && (
                           <span
                             className={`px-3 py-1 rounded-full text-xs font-bold ${
                               animal.status === 'AVAILABLE' || animal.status === 'PROTECT'
@@ -85,8 +126,38 @@ export default function RegisteredAnimals() {
                               ? '입양대기'
                               : animal.status}
                           </span>
-                        </div>
-                      )}
+                        )}
+                        {animal.gender === 'MALE' && (
+                          <span className="px-3 py-1 rounded-full text-xs font-bold bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+                            수컷
+                          </span>
+                        )}
+                        {animal.gender === 'FEMALE' && (
+                          <span className="px-3 py-1 rounded-full text-xs font-bold bg-pink-100 text-pink-800 dark:bg-pink-900/30 dark:text-pink-400">
+                            암컷
+                          </span>
+                        )}
+                        {(!animal.gender || (animal.gender as string) === 'UNKNOWN') && (
+                          <span className="px-3 py-1 rounded-full text-xs font-bold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                            미상
+                          </span>
+                        )}
+                        {(animal.neuterStatus === 'YES' || animal.neutered === true) && (
+                          <span className="px-3 py-1 rounded-full text-xs font-bold bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400">
+                            중성화 완료
+                          </span>
+                        )}
+                        {(animal.neuterStatus === 'NO' || animal.neutered === false) && (
+                          <span className="px-3 py-1 rounded-full text-xs font-bold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                            중성화 미완료
+                          </span>
+                        )}
+                        {animal.neuterStatus === 'UNKNOWN' && (
+                          <span className="px-3 py-1 rounded-full text-xs font-bold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                            중성화 미상
+                          </span>
+                        )}
+                      </div>
                     </div>
                   ) : (
                     <div className="w-full h-56 bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
@@ -157,7 +228,7 @@ export default function RegisteredAnimals() {
             </div>
 
             {/* 페이지네이션 */}
-            {totalPages > 1 && (
+            {actualTotalPages > 1 && (
               <div className="mt-8 flex justify-center items-center gap-2">
                 <button
                   onClick={() => handlePageChange(currentPage - 1)}
@@ -168,7 +239,7 @@ export default function RegisteredAnimals() {
                 </button>
 
                 <div className="flex items-center gap-1">
-                  {Array.from({ length: Math.min(totalPages, 10) }, (_, i) => {
+                  {Array.from({ length: Math.min(actualTotalPages, 10) }, (_, i) => {
                     const pageNum = i;
                     return (
                       <button
@@ -188,7 +259,7 @@ export default function RegisteredAnimals() {
 
                 <button
                   onClick={() => handlePageChange(currentPage + 1)}
-                  disabled={currentPage >= totalPages - 1}
+                  disabled={currentPage >= actualTotalPages - 1}
                   className="px-4 py-2 rounded-lg bg-white dark:bg-gray-800 text-text-main dark:text-white border border-gray-200 dark:border-gray-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                 >
                   <span className="material-symbols-outlined">chevron_right</span>

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -125,6 +125,7 @@ export interface Animal {
   happenDate?: string;         // 발생 일자
   birthYear?: number;           // 출생년도
   specialMark?: string;         // 특이사항
+  apiSource?: 'APMS_ANIMAL' | 'MANUAL'; // 데이터 출처 (APMS 배치 또는 수동 등록)
 }
 
 // 동물 검색 파라미터
@@ -675,6 +676,7 @@ export interface UserInfoResponse {
   nickname: string | null;
   provider: string | null;  // 'EMAIL' | 'GOOGLE' | 'KAKAO' | null
   role: 'ROLE_USER' | 'ROLE_ADMIN' | 'ROLE_SHELTER';
+  careRegNo?: string; // 보호소 등록번호 (ROLE_SHELTER인 경우)
   createdAt: string;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,14 +9,14 @@ export default {
       extend: {
         colors: {
           "primary": "#34d399",
-          "background-light": "#f0fdfa",
-          "background-dark": "#0d1a16",
+          "background-light": "#ffffff",
+          "background-dark": "#0f0f0f",
           "text-light": "#052e16",
           "text-dark": "#d1fae5",
           "card-light": "#ffffff",
-          "card-dark": "#052e16",
-          "border-light": "#99f6e4",
-          "border-dark": "#14532d",
+          "card-dark": "#1a1a1a",
+          "border-light": "#e5e7eb",
+          "border-dark": "#374151",
           // 기존 색상 호환성 유지
           "primary-content": "#0d1b14",
           "secondary-content": "#4c9a73"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,12 +31,13 @@ export default defineConfig({
         target: 'http://localhost:8080', // API Gateway
         changeOrigin: true,
       },
+      // 카테고리 API는 API Gateway를 통해 요청
       '/api/categories': {
-        target: 'http://localhost:8085',
+        target: 'http://localhost:8080', // API Gateway
         changeOrigin: true,
       },
       '/api/option-groups': {
-        target: 'http://localhost:8085',
+        target: 'http://localhost:8080', // API Gateway로 변경
         changeOrigin: true,
       },
       '/api/images': {


### PR DESCRIPTION
## 변경 사항
### 로그인 페이지 UX 개선
- 로고 위치를 카드 바로 위로 이동하여 디자인 일관성 개선
- 로그인 성공 시 alert 제거 (바로 홈으로 이동)
- 로그인 실패 시 커스텀 Toast 알림 및 입력 필드 하단 에러 메시지 표시
- HTML5 기본 validation 제거하고 커스텀 validation 구현
- 이메일 형식 검증 및 비밀번호 입력 검증 추가
- 에러 발생 시 입력 필드 테두리 빨간색으로 변경

### 관리자 페이지 사이드바 통일
- ProductCreate.tsx 사이드바를 AdminSidebar 컴포넌트로 통일
- AdminOptionGroupManagement.tsx 사이드바를 AdminSidebar 컴포넌트로 통일
- 모든 관리자 페이지에서 일관된 사이드바 사용

### AdminSidebar 개선
- 상품관리 드롭다운이 선택된 페이지(/admin/products, /products/new)에서 자동으로 열리도록 개선
- 옵션관리 드롭다운이 선택된 페이지(/admin/option-groups)에서 자동으로 열리도록 개선
- 선택된 메뉴 항목에 볼드 및 강조 스타일 적용
- 로고 클릭 시 메인 페이지(/)로 이동하도록 추가

### API Gateway 연동 개선
- 옵션그룹 API(/api/option-groups)를 API Gateway(8080)로 라우팅하도록 vite.config.ts 수정

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #43 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- 로그인 페이지의 모든 알림을 커스텀 Toast 컴포넌트로 통일하여 일관된 UX 제공
- 관리자 페이지 사이드바를 완전히 통일하여 유지보수성 향상
- 드롭다운 메뉴의 자동 열림 기능으로 사용자 편의성 개선