### PR TITLE
fix: 펫마켓 가격 입력 필드 스피너 제거

### DIFF
--- a/src/components/common/ProductFilterSidebar.tsx
+++ b/src/components/common/ProductFilterSidebar.tsx
@@ -193,7 +193,7 @@ export default function ProductFilterSidebar({
               value={localMinPrice}
               onChange={(e) => setLocalMinPrice(e.target.value)}
               onKeyPress={handleKeyPress}
-              className="w-full h-10 px-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-background-light dark:bg-secondary-dark text-sm"
+              className="w-full h-10 px-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-background-light dark:bg-secondary-dark text-sm [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
             />
             <span className="self-center text-gray-400">~</span>
             <input
@@ -202,7 +202,7 @@ export default function ProductFilterSidebar({
               value={localMaxPrice}
               onChange={(e) => setLocalMaxPrice(e.target.value)}
               onKeyPress={handleKeyPress}
-              className="w-full h-10 px-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-background-light dark:bg-secondary-dark text-sm"
+              className="w-full h-10 px-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-background-light dark:bg-secondary-dark text-sm [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
             />
           </div>
           <p className="text-xs text-gray-400 px-3 mt-1">엔터 또는 검색 버튼으로 적용</p>


### PR DESCRIPTION
## 변경 사항
### 펫마켓 가격 입력 필드 스피너 제거
- ProductFilterSidebar.tsx의 가격 입력 필드(최소/최대)에서 스피너(위/아래 화살표 버튼) 제거
- Tailwind CSS 클래스를 사용하여 브라우저별 스피너 숨김 처리
- Firefox: `[appearance:textfield]` 사용
- Chrome/Safari: `[&::-webkit-inner-spin-button]:appearance-none`, `[&::-webkit-outer-spin-button]:appearance-none` 사용
- 기존 기능 유지 (숫자 입력, 엔터키 검색, 검색 버튼 클릭 등)

## 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Closes #47 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- 네이버 쇼핑 등 주요 쇼핑몰처럼 가격 입력 시 1원 단위 조정은 불필요하므로 스피너를 제거하여 더 깔끔한 UI 제공
- ResetPassword.tsx에서 사용한 것과 동일한 방법을 사용하여 일관성 유지
- 모든 브라우저(Chrome, Safari, Firefox)에서 스피너가 제대로 숨겨지는지 확인