### PR TITLE
fix: 메인 페이지 동물 카드 UI/UX 개선

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -52,10 +52,21 @@ apiClient.interceptors.response.use(
     if (error.response) {
       switch (error.response.status) {
         case 401:
-          console.error('인증 실패: 로그인이 필요합니다');
-          // ✅ Zustand에서 인증 정보 삭제
-          useAuthStore.getState().clearAuth();
-          window.location.href = '/login';
+          // 공개 API는 401 에러 발생 시에도 로그인 리다이렉트하지 않음
+          const requestUrl = error.config?.url || '';
+          
+          // 공개 API 경로 패턴: /api/animals 또는 /api/animals/{id}
+          const isPublicAnimalApi = /^\/api\/animals(\/\d+)?(\?.*)?$/.test(requestUrl);
+          
+          if (isPublicAnimalApi) {
+            // 공개 API는 에러만 로그하고 리다이렉트하지 않음
+            console.warn('공개 API 인증 실패 (리다이렉트 제외):', requestUrl);
+          } else {
+            // 인증이 필요한 API는 로그인 페이지로 리다이렉트
+            console.error('인증 실패: 로그인이 필요합니다');
+            useAuthStore.getState().clearAuth();
+            window.location.href = '/login';
+          }
           break;
         case 403:
           console.error('권한 없음');

--- a/src/components/common/AnimalCardSimple.tsx
+++ b/src/components/common/AnimalCardSimple.tsx
@@ -91,7 +91,7 @@ export default function AnimalCardSimple({ animal }: AnimalCardSimpleProps) {
       className="flex flex-col bg-card-light dark:bg-card-dark rounded-xl overflow-hidden shadow-sm border border-border-light dark:border-border-dark transition-transform hover:-translate-y-1"
     >
       {/* 이미지 */}
-      <div className="aspect-square w-full bg-gray-100 dark:bg-gray-800 overflow-hidden relative">
+      <div className="w-full h-64 bg-gray-100 dark:bg-gray-800 overflow-hidden relative">
         {imageUrl ? (
           <img
             src={imageUrl}


### PR DESCRIPTION
## 변경 사항
### 비로그인 사용자 동물 상세 조회 가능하도록 개선

- 동물 목록 조회(`/api/animals`)와 동물 상세 조회(`/api/animals/{id}`)는 공개 API이므로 비로그인 사용자도 접근 가능해야 함
- 기존에는 모든 API에서 401 에러 발생 시 무조건 로그인 페이지로 리다이렉트하여, 비로그인 사용자가 동물 상세 정보를 볼 수 없었음
- 공개 API 경로에서 401 에러 발생 시 로그인 리다이렉트를 제외하도록 수정
- 정규식을 사용하여 공개 API 경로 패턴 매칭 (`/^\/api\/animals(\/\d+)?(\?.*)?$/`)
- 공개 API의 401 에러는 경고 로그만 출력하고, 인증이 필요한 API는 기존대로 로그인 페이지로 리다이렉트

### 동물 카드 이미지 크기 통일

- AnimalCardSimple 컴포넌트의 이미지 컨테이너를 `aspect-square`에서 고정 높이 `h-64`(256px)로 변경
- 메인 페이지와 동물 목록 페이지의 모든 동물 카드 이미지가 동일한 높이로 표시되어 일관된 UI 제공
- 이미지 비율이 다른 경우에도 `object-cover`로 적절히 표시

## 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Closes #49 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- 공개 API는 인증이 필요하지 않으므로 401 에러 발생 시에도 로그인 페이지로 리다이렉트하지 않아야 함
- 동물 카드 이미지 크기를 통일하여 사용자 경험 개선 및 UI 일관성 확보
- 메인 페이지와 동물 목록 페이지에서 동일한 AnimalCardSimple 컴포넌트를 사용하므로 한 번의 수정으로 모든 페이지에 적용됨