### PR TITLE
feat: 메인 페이지 동물 카드 마우스 드래그 스크롤 기능 추가

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { useRef, useState } from 'react';
 import { getAnimals } from '../api/animals.api';
 import type { Animal } from '../types/api.types';
 import Header from '../components/layout/Header';
@@ -17,6 +18,47 @@ export default function Home() {
 
   // 최근 등록 동물 (10마리)
   const featuredAnimals = data?.content?.slice(0, 10) || [];
+
+  // 마우스 드래그 스크롤을 위한 ref와 state
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [scrollLeft, setScrollLeft] = useState(0);
+
+  // 마우스 드래그 시작
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (!scrollContainerRef.current) return;
+    setIsDragging(true);
+    setStartX(e.pageX - scrollContainerRef.current.offsetLeft);
+    setScrollLeft(scrollContainerRef.current.scrollLeft);
+    scrollContainerRef.current.style.cursor = 'grabbing';
+    scrollContainerRef.current.style.userSelect = 'none';
+  };
+
+  // 마우스 드래그 중
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDragging || !scrollContainerRef.current) return;
+    e.preventDefault();
+    const x = e.pageX - scrollContainerRef.current.offsetLeft;
+    const walk = (x - startX) * 2; // 스크롤 속도 조절
+    scrollContainerRef.current.scrollLeft = scrollLeft - walk;
+  };
+
+  // 마우스 드래그 종료
+  const handleMouseUp = () => {
+    if (!scrollContainerRef.current) return;
+    setIsDragging(false);
+    scrollContainerRef.current.style.cursor = 'grab';
+    scrollContainerRef.current.style.userSelect = 'auto';
+  };
+
+  // 마우스가 영역을 벗어났을 때
+  const handleMouseLeave = () => {
+    if (!scrollContainerRef.current) return;
+    setIsDragging(false);
+    scrollContainerRef.current.style.cursor = 'grab';
+    scrollContainerRef.current.style.userSelect = 'auto';
+  };
 
   return (
     <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark">
@@ -99,8 +141,16 @@ export default function Home() {
                 전체보기
               </Link>
             </div>
-            <div className="flex overflow-x-auto [-ms-scrollbar-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden -mx-4 sm:-mx-6 lg:-mx-8 snap-x snap-mandatory">
-              <div className="flex items-stretch p-4 sm:p-6 lg:p-8 gap-6">
+            <div
+              ref={scrollContainerRef}
+              className="flex flex-row overflow-x-hidden -mx-4 sm:-mx-6 lg:-mx-8 snap-x snap-mandatory cursor-grab active:cursor-grabbing select-none"
+              onMouseDown={handleMouseDown}
+              onMouseMove={handleMouseMove}
+              onMouseUp={handleMouseUp}
+              onMouseLeave={handleMouseLeave}
+              onWheel={(e) => e.preventDefault()} // 마우스 휠 스크롤 방지
+            >
+              <div className="flex flex-row items-stretch p-4 sm:p-6 lg:p-8 gap-6">
                 {featuredAnimals.length > 0 ? (
                   featuredAnimals.map((animal: Animal) => (
                     <div key={animal.id} className="min-w-[320px] max-w-[320px] flex-shrink-0 snap-start">


### PR DESCRIPTION
## 변경 사항
### 메인 페이지 동물 카드 마우스 드래그 스크롤 기능 추가

- 마우스로 클릭 후 드래그하여 동물 카드를 좌우로 스크롤할 수 있는 기능 구현
- 스크롤바와 마우스 휠 스크롤은 비활성화하여 드래그 스크롤만 사용 가능하도록 설정
- 드래그 중 커서 변경 (grab → grabbing) 및 텍스트 선택 방지
- 카드 클릭 시 상세 페이지로 이동하는 기존 기능 유지

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Closes #53 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 구현 세부사항
- `useRef`와 `useState`를 사용하여 드래그 상태 관리
- `handleMouseDown`, `handleMouseMove`, `handleMouseUp`, `handleMouseLeave` 이벤트 핸들러 구현
- `overflow-x-hidden`으로 스크롤바 숨김
- `onWheel` 이벤트에서 `preventDefault`로 마우스 휠 스크롤 방지
- `cursor-grab` 및 `active:cursor-grabbing` 클래스로 드래그 중 커서 변경
- `select-none` 클래스로 드래그 중 텍스트 선택 방지
- 스크롤 속도는 `walk = (x - startX) * 2`로 조절 (2배 속도)