### PR TITLE
fix: 메인 페이지 드래그 스크롤 실시간 반영 수정

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -22,8 +22,8 @@ export default function Home() {
   // 마우스 드래그 스크롤을 위한 ref와 state
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
-  const [startX, setStartX] = useState(0);
-  const [scrollLeft, setScrollLeft] = useState(0);
+  const startXRef = useRef(0);
+  const scrollLeftRef = useRef(0);
   const lastXRef = useRef(0);
   const lastTimeRef = useRef(0);
   const dragDistanceRef = useRef(0); // 드래그 거리 추적 (클릭 vs 드래그 구분용)
@@ -60,9 +60,9 @@ export default function Home() {
     const x = e.pageX - rect.left;
     
     setIsDragging(true);
-    setStartX(x);
+    startXRef.current = x;
     lastXRef.current = x;
-    setScrollLeft(scrollContainerRef.current.scrollLeft);
+    scrollLeftRef.current = scrollContainerRef.current.scrollLeft;
     lastTimeRef.current = Date.now();
     dragDistanceRef.current = 0;
     
@@ -81,12 +81,12 @@ export default function Home() {
       const currentTime = Date.now();
       
       // 드래그 거리 계산
-      const distance = Math.abs(x - startX);
+      const distance = Math.abs(x - startXRef.current);
       dragDistanceRef.current = distance;
       
       // 실시간 스크롤 (초기 scrollLeft 기준으로 상대적 이동)
-      const walk = (x - startX) * 2; // 스크롤 속도 조절
-      const newScrollLeft = scrollLeft - walk;
+      const walk = (x - startXRef.current) * 2; // 스크롤 속도 조절
+      const newScrollLeft = scrollLeftRef.current - walk;
       scrollContainerRef.current.scrollLeft = newScrollLeft;
       
       // 마지막 위치와 시간 업데이트 (속도 계산용)
@@ -107,7 +107,7 @@ export default function Home() {
         
         if (timeDiff > 0 && scrollContainerRef.current) {
           const currentX = lastXRef.current;
-          const distance = currentX - startX;
+          const distance = currentX - startXRef.current;
           const velocity = (distance * 2) / (timeDiff / 16); // 프레임 단위로 변환
           animateInertialScroll(velocity);
         }
@@ -127,7 +127,7 @@ export default function Home() {
         document.removeEventListener('mouseup', handleMouseUp);
       };
     }
-  }, [isDragging, startX, scrollLeft]);
+  }, [isDragging]);
 
   // 마우스가 영역을 벗어났을 때
   const handleMouseLeave = () => {


### PR DESCRIPTION
## 변경 사항
### 메인 페이지 드래그 스크롤 실시간 반영 수정
- 드래그 중 카드가 실시간으로 좌우 슬라이딩되도록 수정
- `startX`와 `scrollLeft`를 state에서 ref로 변경하여 실시간 스크롤 반영
- `useEffect` dependency 최적화로 불필요한 리렌더링 방지

## 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Close #57

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- 이전 PR에서 드래그 스크롤이 실시간으로 반영되지 않던 문제 수정
- state 대신 ref를 사용하여 드래그 중 실시간 스크롤 업데이트 보장
- 드래그 중 카드가 부드럽게 좌우로 슬라이딩되는 것을 확인