### PR TITLE
fix: 메인 페이지 동물 카드 드래그 스크롤 불가 버그 수정

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -77,18 +77,6 @@ export default function Home() {
   const handleMouseDown = (e: React.MouseEvent) => {
     if (!scrollContainerRef.current) return;
     
-    // 클릭 타겟이 Link(a 태그)인 경우 드래그 로직을 시작하지 않음
-    const target = e.target as HTMLElement;
-    const isLink = target.closest('a') !== null;
-    
-    // Link를 클릭한 경우 드래그 로직을 시작하지 않고 즉시 리턴
-    // 이전 드래그 거리도 초기화하여 클릭이 정상 작동하도록 보장
-    if (isLink) {
-      finalDragDistanceRef.current = 0;
-      return;
-    }
-    
-    // Link가 아닌 경우에만 preventDefault 호출 및 드래그 로직 시작
     e.preventDefault();
     
     const container = scrollContainerRef.current;


### PR DESCRIPTION
## 변경 사항

### 메인 페이지 동물 카드 드래그 스크롤 버그 수정
- `handleMouseDown`에서 `isLink` 체크 로직 제거
- `AnimalCardSimple` 전체가 `<Link>`로 감싸져 있어 드래그가 시작되지 않던 문제 해결
- 기존 `onCardClick`의 드래그 거리 판별(10px 기준)로 클릭/드래그 구분 정상 작동

## 작업 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명

- 서버 점검 팝업 추가(#66) 시 `isLink` 가드가 함께 추가되면서 발생한 버그
- 카드 영역 전체가 `<Link>`이므로 `target.closest('a')`가 항상 true → 드래그 시작 불가
- 클릭과 드래그 구분은 `onCardClick`에서 10px 거리 기준으로 이미 처리되고 있어 안전