### PR TITLE
feat: 유기동물 통계 대시보드 및 메인 페이지 통계 위젯 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ import AdoptionDetail from './pages/AdoptionDetail.tsx';
 import AdoptionCreate from './pages/AdoptionCreate.tsx';
 import AdoptionEdit from './pages/AdoptionEdit.tsx';
 import OAuthCallback from './pages/OAuthCallback.tsx';
+import AnimalStats from './pages/AnimalStats.tsx';
 
 // 개발 환경에서만 window에 등록 (디버깅용)
 if (import.meta.env.DEV) {
@@ -153,6 +154,7 @@ function App() {
       <Route path="/reset-password" element={<ResetPassword />} />
       <Route path="/oauth/callback" element={<OAuthCallback />} />
       <Route path="/animals" element={<Animals />} />
+      <Route path="/animals/stats" element={<AnimalStats />} />
       <Route path="/animals/:id" element={<AnimalDetail />} />
       <Route
         path="/animals/new"

--- a/src/api/animalStats.api.ts
+++ b/src/api/animalStats.api.ts
@@ -1,0 +1,31 @@
+import apiClient from './client';
+import type {
+  TodayAnimalStats,
+  AnimalStatusStats,
+  RegionalAnimalStats,
+} from '../types/api.types';
+
+export const getTodayAnimalStats = async (): Promise<TodayAnimalStats> => {
+  const response = await apiClient.get<TodayAnimalStats>('/api/v1/animals/stats/today');
+  return response.data;
+};
+
+export const getAnimalStatusStats = async (
+  startDate?: string,
+  endDate?: string,
+): Promise<AnimalStatusStats[]> => {
+  const response = await apiClient.get<AnimalStatusStats[]>('/api/v1/animals/stats/status', {
+    params: { startDate, endDate },
+  });
+  return response.data;
+};
+
+export const getRegionalAnimalStats = async (
+  startDate?: string,
+  endDate?: string,
+): Promise<RegionalAnimalStats[]> => {
+  const response = await apiClient.get<RegionalAnimalStats[]>('/api/v1/animals/stats/regional', {
+    params: { startDate, endDate },
+  });
+  return response.data;
+};

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -42,6 +42,12 @@ export default function Header() {
               동물 검색
             </Link>
             <Link
+              to="/animals/stats"
+              className="text-primary-content dark:text-gray-300 text-sm font-medium leading-normal hover:text-primary dark:hover:text-primary transition-colors"
+            >
+              유기동물 현황
+            </Link>
+            <Link
               to="/adoption"
               className="text-primary-content dark:text-gray-300 text-sm font-medium leading-normal hover:text-primary dark:hover:text-primary transition-colors"
             >
@@ -138,6 +144,13 @@ export default function Header() {
                 onClick={() => setIsMobileMenuOpen(false)}
               >
                 동물 검색
+              </Link>
+              <Link
+                to="/animals/stats"
+                className="text-primary-content dark:text-gray-300 text-sm font-medium hover:text-primary dark:hover:text-primary transition-colors"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                유기동물 현황
               </Link>
               <Link
                 to="/adoption"

--- a/src/pages/AnimalStats.tsx
+++ b/src/pages/AnimalStats.tsx
@@ -1,0 +1,298 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import {
+  getTodayAnimalStats,
+  getAnimalStatusStats,
+  getRegionalAnimalStats,
+} from '../api/animalStats.api';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+
+type PeriodType = '30days' | '90days' | '180days' | 'custom';
+
+const STATUS_COLORS: Record<string, { bg: string; bar: string }> = {
+  PROTECT: { bg: 'bg-green-100 dark:bg-green-900/30', bar: 'bg-green-500' },
+  ADOPTED: { bg: 'bg-blue-100 dark:bg-blue-900/30', bar: 'bg-blue-500' },
+  NATURAL_DEATH: { bg: 'bg-gray-200 dark:bg-gray-700', bar: 'bg-gray-500' },
+  RETURNED: { bg: 'bg-purple-100 dark:bg-purple-900/30', bar: 'bg-purple-500' },
+  EUTHANIZED: { bg: 'bg-red-100 dark:bg-red-900/30', bar: 'bg-red-500' },
+  DONATED: { bg: 'bg-yellow-100 dark:bg-yellow-900/30', bar: 'bg-yellow-500' },
+  RELEASED: { bg: 'bg-teal-100 dark:bg-teal-900/30', bar: 'bg-teal-500' },
+};
+
+function getKSTDate(date: Date): string {
+  const kstOffset = 9 * 60;
+  const utc = date.getTime() + date.getTimezoneOffset() * 60000;
+  const kstDate = new Date(utc + kstOffset * 60000);
+  const year = kstDate.getFullYear();
+  const month = String(kstDate.getMonth() + 1).padStart(2, '0');
+  const day = String(kstDate.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export default function AnimalStats() {
+  const [period, setPeriod] = useState<PeriodType>('30days');
+  const [customStart, setCustomStart] = useState('');
+  const [customEnd, setCustomEnd] = useState('');
+
+  const getDateRange = () => {
+    const today = new Date();
+    const end = getKSTDate(today);
+    let start = end;
+    switch (period) {
+      case '30days': {
+        const d = new Date(today);
+        d.setDate(today.getDate() - 29);
+        start = getKSTDate(d);
+        break;
+      }
+      case '90days': {
+        const d = new Date(today);
+        d.setDate(today.getDate() - 89);
+        start = getKSTDate(d);
+        break;
+      }
+      case '180days': {
+        const d = new Date(today);
+        d.setDate(today.getDate() - 179);
+        start = getKSTDate(d);
+        break;
+      }
+      case 'custom':
+        break;
+    }
+    return { start, end };
+  };
+
+  const { start: calcStart, end: calcEnd } = getDateRange();
+  const startDate = period === 'custom' && customStart ? customStart : calcStart;
+  const endDate = period === 'custom' && customEnd ? customEnd : calcEnd;
+
+  const { data: todayStats } = useQuery({
+    queryKey: ['today-animal-stats'],
+    queryFn: getTodayAnimalStats,
+  });
+
+  const { data: statusStats = [], isLoading: isStatusLoading } = useQuery({
+    queryKey: ['animal-status-stats', startDate, endDate],
+    queryFn: () => getAnimalStatusStats(startDate, endDate),
+  });
+
+  const { data: regionalStats = [], isLoading: isRegionalLoading } = useQuery({
+    queryKey: ['animal-regional-stats', startDate, endDate],
+    queryFn: () => getRegionalAnimalStats(startDate, endDate),
+  });
+
+  const statusTotal = statusStats.reduce((sum, s) => sum + s.count, 0);
+  const statusMax = statusStats.length > 0 ? Math.max(...statusStats.map((s) => s.count)) : 1;
+  const regionalMax = regionalStats.length > 0 ? Math.max(...regionalStats.map((r) => r.count)) : 1;
+
+  const periodButtons: { key: PeriodType; label: string }[] = [
+    { key: '30days', label: '최근 30일' },
+    { key: '90days', label: '최근 90일' },
+    { key: '180days', label: '최근 180일' },
+    { key: 'custom', label: '직접 선택' },
+  ];
+
+  return (
+    <div className="relative flex min-h-screen w-full flex-col bg-background-light dark:bg-background-dark">
+      <Header />
+
+      <main className="flex flex-col items-center w-full">
+        <div className="flex flex-col max-w-5xl w-full px-4 sm:px-6 lg:px-8 py-10 md:py-16">
+          {/* 페이지 헤더 */}
+          <div className="mb-10">
+            <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 mb-4">
+              <Link to="/" className="hover:text-primary transition-colors">홈</Link>
+              <span className="material-symbols-outlined text-xs">chevron_right</span>
+              <span className="text-text-light dark:text-text-dark font-medium">유기동물 통계</span>
+            </div>
+            <h1 className="text-3xl md:text-4xl font-black text-text-light dark:text-text-dark tracking-tight">
+              유기동물 통계
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mt-2">
+              유기동물 현황을 한눈에 확인하고, 입양에 관심을 가져주세요.
+            </p>
+          </div>
+
+          {/* 오늘의 통계 요약 */}
+          <section className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
+            <div className="rounded-xl bg-blue-50 dark:bg-blue-950/30 border border-blue-200/60 dark:border-blue-800/40 p-5 text-center">
+              <p className="text-xs font-semibold text-blue-500 dark:text-blue-400 mb-1">오늘 구조</p>
+              <p className="text-3xl font-black text-blue-700 dark:text-blue-300">
+                {todayStats?.rescuedToday ?? '—'}
+                <span className="text-sm font-semibold text-blue-500/70 ml-1">마리</span>
+              </p>
+            </div>
+            <div className="rounded-xl bg-green-50 dark:bg-green-950/30 border border-green-200/60 dark:border-green-800/40 p-5 text-center">
+              <p className="text-xs font-semibold text-green-500 dark:text-green-400 mb-1">오늘 입양</p>
+              <p className="text-3xl font-black text-green-700 dark:text-green-300">
+                {todayStats?.adoptedToday ?? '—'}
+                <span className="text-sm font-semibold text-green-500/70 ml-1">마리</span>
+              </p>
+            </div>
+            <div className="rounded-xl bg-orange-50 dark:bg-orange-950/30 border border-orange-200/60 dark:border-orange-800/40 p-5 text-center">
+              <p className="text-xs font-semibold text-orange-500 dark:text-orange-400 mb-1">
+                {todayStats?.date ? todayStats.date.replace(/-/g, '.') : '—'}
+              </p>
+              <p className="text-sm font-bold text-orange-700 dark:text-orange-300 mt-1">
+                따뜻한 가족을 기다리는<br />아이들이 있습니다
+              </p>
+            </div>
+          </section>
+
+          {/* 기간 필터 */}
+          <div className="flex flex-wrap items-end gap-3 mb-8">
+            <div className="flex rounded-lg bg-gray-100 dark:bg-gray-800 p-1 gap-1">
+              {periodButtons.map((btn) => (
+                <button
+                  key={btn.key}
+                  onClick={() => setPeriod(btn.key)}
+                  className={`px-3 py-1.5 rounded-md text-sm font-semibold transition-colors ${
+                    period === btn.key
+                      ? 'bg-white dark:bg-gray-700 text-text-light dark:text-text-dark shadow-sm'
+                      : 'text-gray-500 dark:text-gray-400 hover:text-text-light dark:hover:text-text-dark'
+                  }`}
+                >
+                  {btn.label}
+                </button>
+              ))}
+            </div>
+            {period === 'custom' && (
+              <div className="flex items-center gap-2">
+                <input
+                  type="date"
+                  value={customStart}
+                  onChange={(e) => setCustomStart(e.target.value)}
+                  className="px-3 py-1.5 h-9 w-36 bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 text-text-light dark:text-text-dark text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                />
+                <span className="text-gray-400">~</span>
+                <input
+                  type="date"
+                  value={customEnd}
+                  onChange={(e) => setCustomEnd(e.target.value)}
+                  className="px-3 py-1.5 h-9 w-36 bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 text-text-light dark:text-text-dark text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                />
+              </div>
+            )}
+          </div>
+
+          {/* 상태별 현황 */}
+          <section className="mb-12">
+            <div className="flex items-center justify-between mb-5">
+              <h2 className="text-xl font-bold text-text-light dark:text-text-dark">상태별 현황</h2>
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {startDate} ~ {endDate} · 총 {statusTotal.toLocaleString()}건
+              </span>
+            </div>
+
+            {isStatusLoading ? (
+              <div className="flex items-center justify-center py-16 text-gray-400">
+                <span className="material-symbols-outlined animate-spin mr-2">progress_activity</span>
+                불러오는 중...
+              </div>
+            ) : statusStats.length === 0 ? (
+              <div className="text-center py-16 text-gray-400">데이터가 없습니다.</div>
+            ) : (
+              <div className="bg-white dark:bg-gray-900 rounded-xl border border-border-light dark:border-border-dark shadow-sm overflow-hidden">
+                <div className="divide-y divide-border-light dark:divide-border-dark">
+                  {statusStats.map((stat) => {
+                    const pct = statusTotal > 0 ? ((stat.count / statusTotal) * 100).toFixed(1) : '0';
+                    const barWidth = statusMax > 0 ? (stat.count / statusMax) * 100 : 0;
+                    const colors = STATUS_COLORS[stat.status] || { bg: 'bg-gray-100 dark:bg-gray-800', bar: 'bg-gray-400' };
+                    return (
+                      <div key={stat.status} className="flex items-center gap-4 px-5 py-4">
+                        <span className={`text-xs font-bold rounded-full px-3 py-1 whitespace-nowrap ${colors.bg} text-gray-700 dark:text-gray-300`}>
+                          {stat.label}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <div className="w-full h-6 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+                            <div
+                              className={`h-full rounded-full ${colors.bar} transition-all duration-500`}
+                              style={{ width: `${barWidth}%` }}
+                            />
+                          </div>
+                        </div>
+                        <div className="flex items-baseline gap-2 flex-shrink-0 w-32 justify-end">
+                          <span className="text-lg font-black text-text-light dark:text-text-dark">
+                            {stat.count.toLocaleString()}
+                          </span>
+                          <span className="text-xs text-gray-400 dark:text-gray-500">({pct}%)</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </section>
+
+          {/* 지역별 구조 통계 */}
+          <section className="mb-12">
+            <div className="flex items-center justify-between mb-5">
+              <h2 className="text-xl font-bold text-text-light dark:text-text-dark">지역별 구조 통계</h2>
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {startDate} ~ {endDate}
+              </span>
+            </div>
+
+            {isRegionalLoading ? (
+              <div className="flex items-center justify-center py-16 text-gray-400">
+                <span className="material-symbols-outlined animate-spin mr-2">progress_activity</span>
+                불러오는 중...
+              </div>
+            ) : regionalStats.length === 0 ? (
+              <div className="text-center py-16 text-gray-400">데이터가 없습니다.</div>
+            ) : (
+              <div className="bg-white dark:bg-gray-900 rounded-xl border border-border-light dark:border-border-dark shadow-sm overflow-hidden">
+                <div className="divide-y divide-border-light dark:divide-border-dark">
+                  {regionalStats.map((region, idx) => {
+                    const barWidth = regionalMax > 0 ? (region.count / regionalMax) * 100 : 0;
+                    return (
+                      <div key={region.region} className="flex items-center gap-4 px-5 py-3.5">
+                        <span className="text-sm font-bold text-gray-400 dark:text-gray-500 w-6 text-right">
+                          {idx + 1}
+                        </span>
+                        <span className="text-sm font-semibold text-text-light dark:text-text-dark w-20 flex-shrink-0">
+                          {region.region}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <div className="w-full h-5 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+                            <div
+                              className="h-full rounded-full bg-primary/80 transition-all duration-500"
+                              style={{ width: `${barWidth}%` }}
+                            />
+                          </div>
+                        </div>
+                        <span className="text-sm font-bold text-text-light dark:text-text-dark flex-shrink-0 w-20 text-right">
+                          {region.count.toLocaleString()}건
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </section>
+
+          {/* 하단 안내 */}
+          <div className="text-center py-8">
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+              이 통계는 공공데이터 기반으로 제공되며, 실시간 데이터와 차이가 있을 수 있습니다.
+            </p>
+            <Link
+              to="/animals"
+              className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-content rounded-full text-sm font-bold hover:opacity-90 transition-opacity"
+            >
+              <span className="material-symbols-outlined text-lg">pets</span>
+              입양 가능한 동물 보러가기
+            </Link>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useRef, useState, useEffect } from 'react';
 import { getAnimals } from '../api/animals.api';
+import { getTodayAnimalStats, getAnimalStatusStats } from '../api/animalStats.api';
 import type { Animal } from '../types/api.types';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
@@ -10,6 +11,28 @@ import QuickNavCard from '../components/common/QuickNavCard';
 import AdoptionStory from '../components/common/AdoptionStory';
 
 export default function Home() {
+  const { data: todayStats } = useQuery({
+    queryKey: ['today-animal-stats'],
+    queryFn: getTodayAnimalStats,
+  });
+
+  const { data: statusStats } = useQuery({
+    queryKey: ['animal-status-stats'],
+    queryFn: () => getAnimalStatusStats(),
+  });
+
+  const statsRates = (() => {
+    if (!statusStats?.length) return null;
+    const total = statusStats.reduce((sum, s) => sum + s.count, 0);
+    if (total === 0) return null;
+    const adopted = statusStats.find((s) => s.status === 'ADOPTED')?.count ?? 0;
+    const euthanized = statusStats.find((s) => s.status === 'EUTHANIZED')?.count ?? 0;
+    return {
+      adoptionRate: ((adopted / total) * 100).toFixed(1),
+      euthanasiaRate: ((euthanized / total) * 100).toFixed(1),
+    };
+  })();
+
   // 동물 데이터 가져오기 (실제 백엔드 API)
   const { data } = useQuery({
     queryKey: ['featured-animals'],
@@ -334,6 +357,64 @@ export default function Home() {
                 imageUrl="https://lh3.googleusercontent.com/aida-public/AB6AXuBdBJ6x-ervqeL_a8y7L6tn1vBA4JV7fJsMi6eCQrQ-iA3rlKTiDf9AGlKdxSSWuq9-a2nsr2sB7UKiPnPpyj--ShW2aJ7x7ocg4gXNKxXLsnqdVhUNNHQvP6YAreAp8d-VwagvNVDZZDyBxLd1lGsWE8Dhk7CPkke0PZ2A_ZOWmbKhwhqj1WdtatVBJy9HLVot03wDa3Oq_cwtEXOpISRog4YjV6jnhTWiFLfSr9fRTGfZ4wUJH3mfWQ7i21QN-U7i6jxB_6FhSY8"
                 linkTo="/products"
               />
+            </div>
+          </section>
+
+          {/* Today's Animal Stats */}
+          <section className="w-full mt-16 md:mt-24">
+            <div className="rounded-2xl bg-white dark:bg-gray-900 border border-border-light dark:border-border-dark shadow-sm overflow-hidden">
+              <div className="flex items-center justify-between px-5 py-3 border-b border-border-light dark:border-border-dark bg-gray-50/50 dark:bg-gray-800/50">
+                <div className="flex items-center gap-2">
+                  <span className="material-symbols-outlined text-lg text-primary">bar_chart</span>
+                  <span className="text-sm font-bold text-text-light dark:text-text-dark">
+                    {todayStats?.date
+                      ? `${todayStats.date.replace(/-/g, '.')} 유기동물 통계`
+                      : '유기동물 통계'}
+                  </span>
+                </div>
+                <Link to="/animals/stats" className="text-primary text-xs font-bold hover:underline flex items-center gap-0.5">
+                  자세히 보기
+                  <span className="material-symbols-outlined text-sm">chevron_right</span>
+                </Link>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-border-light dark:divide-border-dark">
+                <div className="flex items-center gap-4 px-5 py-5">
+                  <div className="size-11 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center flex-shrink-0">
+                    <span className="material-symbols-outlined text-xl text-blue-500 dark:text-blue-400">pets</span>
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">구조</p>
+                    <p className="text-2xl font-black text-text-light dark:text-text-dark tracking-tight">
+                      {todayStats?.rescuedToday ?? '—'}
+                      <span className="text-sm font-semibold text-gray-500 dark:text-gray-400 ml-1">마리</span>
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-4 px-5 py-5">
+                  <div className="size-11 rounded-full bg-green-100 dark:bg-green-900/40 flex items-center justify-center flex-shrink-0">
+                    <span className="material-symbols-outlined text-xl text-green-500 dark:text-green-400">favorite</span>
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">입양률</p>
+                    <p className="text-2xl font-black text-green-600 dark:text-green-400 tracking-tight">
+                      {statsRates?.adoptionRate ?? '—'}
+                      <span className="text-sm font-semibold ml-0.5">%</span>
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-4 px-5 py-5">
+                  <div className="size-11 rounded-full bg-red-100 dark:bg-red-900/40 flex items-center justify-center flex-shrink-0">
+                    <span className="material-symbols-outlined text-xl text-red-500 dark:text-red-400">warning</span>
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">안락사율</p>
+                    <p className="text-2xl font-black text-red-600 dark:text-red-400 tracking-tight">
+                      {statsRates?.euthanasiaRate ?? '—'}
+                      <span className="text-sm font-semibold ml-0.5">%</span>
+                    </p>
+                  </div>
+                </div>
+              </div>
             </div>
           </section>
 

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -715,3 +715,21 @@ export interface FavoriteListResponse {
   totalCount: number;
   favorites: FavoriteWithAnimalDto[];
 }
+
+// 공개 유기동물 통계
+export interface TodayAnimalStats {
+  date: string;
+  rescuedToday: number;
+  adoptedToday: number;
+}
+
+export interface AnimalStatusStats {
+  status: string;
+  label: string;
+  count: number;
+}
+
+export interface RegionalAnimalStats {
+  region: string;
+  count: number;
+}


### PR DESCRIPTION
## 변경 사항

### 공개 통계 API 연동
- `animalStats.api.ts` 신규 생성 (공개 API 3개 함수)
- `api.types.ts`에 `TodayAnimalStats`, `AnimalStatusStats`, `RegionalAnimalStats` 타입 추가

### 메인 페이지 통계 위젯
- Quick Navigation Cards 아래에 오늘의 유기동물 통계 섹션 추가
- 구조 수(마리) / 입양률(%) / 안락사율(%) 콤팩트 카드 형태
- 입양률·안락사율은 상태별 현황 API 데이터에서 프론트에서 계산
- "자세히 보기" 링크로 통계 페이지 연결

### 통계 전용 페이지 (`/animals/stats`)
- `AnimalStats.tsx` 신규 생성 (공개 페이지, 인증 불필요)
- 오늘의 통계 요약 (구조 수, 입양 수)
- 상태별 현황: Tailwind 기반 가로 막대 그래프 + 건수 + 비율(%)
- 지역별 구조 통계: 순위 + 지역명 + 막대 그래프 + 건수
- 기간 필터: 최근 30일 / 90일 / 180일 / 직접 선택
- 반응형 및 다크모드 지원

### 라우팅 및 네비게이션
- `App.tsx`에 `/animals/stats` 공개 라우트 추가 (`/animals/:id` 위에 배치하여 충돌 방지)
- `Header.tsx`에 "유기동물 현황" 메뉴 추가 (데스크톱 + 모바일)

## 작업 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명

- 통계 API 3개는 모두 인증 불필요한 공개 API
- 방문자에게 유기동물 현황 수치를 노출하여 입양 관심 유도 목적