### PR TITLE
fix: 동물 검색 총 마릿수 수정 및 브레드크럼 텍스트 통일

### DIFF
--- a/src/pages/AnimalDetail.tsx
+++ b/src/pages/AnimalDetail.tsx
@@ -262,7 +262,7 @@ export default function AnimalDetail() {
               </>
             ) : (
               <button onClick={() => navigate('/animals')} className="text-secondary dark:text-primary hover:underline">
-                보호동물 찾기
+                동물 검색
               </button>
             )}
             <span className="text-secondary dark:text-primary">/</span>

--- a/src/pages/Animals.tsx
+++ b/src/pages/Animals.tsx
@@ -116,16 +116,6 @@ export default function Animals() {
   const totalPages = data?.totalPages || 0;
   const currentPage = data?.number || 0;
   
-  // 실제로 표시되는 동물 중 "기다리고 있는" 동물만 카운트
-  // PROTECT(보호중), ADOPTION_PENDING(입양대기중) 상태만 카운트
-  const waitingAnimals = animals.filter(animal => 
-    animal.status === 'PROTECT' || animal.status === 'ADOPTION_PENDING'
-  );
-  
-  // 디버깅: totalElements 확인
-  console.log('Animals 페이지 - totalElements:', totalElements);
-  console.log('Animals 페이지 - 실제 표시되는 동물 수:', animals.length);
-  console.log('Animals 페이지 - 기다리는 동물 수:', waitingAnimals.length);
 
   return (
     <div className="min-h-screen bg-background-light dark:bg-background-dark font-display text-text-light dark:text-text-dark">
@@ -155,7 +145,7 @@ export default function Animals() {
               <p className="text-base text-gray-600 dark:text-gray-400">
                 {animals.length > 0 ? (
                   <>
-                    총 <span className="font-bold text-primary">{waitingAnimals.length.toLocaleString()}</span> 마리의 친구들이 기다리고 있어요
+                    총 <span className="font-bold text-primary">{totalElements.toLocaleString()}</span> 마리의 친구들이 기다리고 있어요
                   </>
                 ) : (
                   '동물 정보를 불러오는 중...'


### PR DESCRIPTION
## 변경 사항

### 동물 검색 페이지 총 마릿수 수정
- `waitingAnimals.length` (현재 페이지 내 필터 결과) → `totalElements` (서버 전체 결과 수)로 변경
- 기존에는 한 페이지에 로드된 동물 중 보호중/입양대기 상태만 카운트하여 실제 전체 수와 불일치
- 디버깅용 `console.log` 3개 제거

### 브레드크럼 텍스트 통일
- `AnimalDetail.tsx` 브레드크럼: "보호동물 찾기" → "동물 검색"
- Header 네비게이션의 "동물 검색"과 통일

## 작업 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명

- 동물 검색 페이지에서 표시되는 총 마릿수가 실제 전체 수와 다르던 문제 수정
- 페이지 내 명칭을 Header 네비게이션과 통일