### PR TITLE
fix: 메인 통계 위젯 날짜 파라미터 명시 및 라벨 기간 표기

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,9 +16,17 @@ export default function Home() {
     queryFn: getTodayAnimalStats,
   });
 
+  const stats30dRange = (() => {
+    const today = new Date();
+    const end = today.toISOString().slice(0, 10);
+    const start = new Date(today);
+    start.setDate(today.getDate() - 29);
+    return { start: start.toISOString().slice(0, 10), end };
+  })();
+
   const { data: statusStats } = useQuery({
-    queryKey: ['animal-status-stats'],
-    queryFn: () => getAnimalStatusStats(),
+    queryKey: ['animal-status-stats', stats30dRange.start, stats30dRange.end],
+    queryFn: () => getAnimalStatusStats(stats30dRange.start, stats30dRange.end),
   });
 
   const statsRates = (() => {
@@ -365,9 +373,7 @@ export default function Home() {
             <div className="rounded-2xl bg-white dark:bg-gray-900 border border-border-light dark:border-border-dark shadow-sm overflow-hidden">
               <div className="flex items-center justify-between px-5 py-3 border-b border-border-light dark:border-border-dark">
                 <span className="text-sm font-bold text-text-light dark:text-text-dark">
-                  {todayStats?.date
-                    ? `${todayStats.date.replace(/-/g, '.')} 유기동물 통계`
-                    : '유기동물 통계'}
+                  유기동물 통계
                 </span>
                 <Link to="/animals/stats" className="text-gray-400 dark:text-gray-500 text-xs font-semibold hover:text-text-light dark:hover:text-text-dark transition-colors flex items-center gap-0.5">
                   자세히 보기
@@ -376,21 +382,21 @@ export default function Home() {
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-border-light dark:divide-border-dark">
                 <div className="px-5 py-5 text-center">
-                  <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">구조</p>
+                  <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">오늘 구조</p>
                   <p className="text-2xl font-black text-text-light dark:text-text-dark tracking-tight">
                     {todayStats?.rescuedToday ?? '—'}
                     <span className="text-sm font-medium text-gray-400 ml-1">마리</span>
                   </p>
                 </div>
                 <div className="px-5 py-5 text-center">
-                  <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">입양률</p>
+                  <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">입양률 (최근 30일)</p>
                   <p className="text-2xl font-black text-text-light dark:text-text-dark tracking-tight">
                     {statsRates?.adoptionRate ?? '—'}
                     <span className="text-sm font-medium text-gray-400 ml-0.5">%</span>
                   </p>
                 </div>
                 <div className="px-5 py-5 text-center">
-                  <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">안락사율</p>
+                  <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">안락사율 (최근 30일)</p>
                   <p className="text-2xl font-black text-text-light dark:text-text-dark tracking-tight">
                     {statsRates?.euthanasiaRate ?? '—'}
                     <span className="text-sm font-medium text-gray-400 ml-0.5">%</span>


### PR DESCRIPTION
## 변경 사항

### 메인 페이지 통계 위젯 개선
- status API 호출 시 날짜 파라미터 명시적 전달 (최근 30일)
- 기존: 파라미터 없이 호출 → 백엔드 기본값에 의존
- 변경: `startDate`, `endDate`를 프론트에서 계산하여 전달
- 각 항목의 기간 기준을 라벨에 명시
  - "구조" → "오늘 구조"
  - "입양률" → "입양률 (최근 30일)"
  - "안락사율" → "안락사율 (최근 30일)"
- 헤더에서 날짜 제거: "2026.03.09 유기동물 통계" → "유기동물 통계"

## 작업 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명

- 백엔드에서 날짜 파라미터 필수로 변경 예정에 따른 프론트 선행 수정
- 기간 기준이 다른 항목들의 라벨을 정확하게 명시하여 사용자 혼란 방지