### PR TITLE
fix: 지도 지역명 매핑 수정 (축약명·현행명 대응)

### DIFF
--- a/src/pages/AnimalStats.tsx
+++ b/src/pages/AnimalStats.tsx
@@ -12,9 +12,31 @@ import Footer from '../components/layout/Footer';
 
 const TOPO_URL = '/korea-provinces-topo.json';
 
-const NAME_MAP: Record<string, string> = {
+const TOPO_DISPLAY_MAP: Record<string, string> = {
   '강원도': '강원특별자치도',
   '전라북도': '전북특별자치도',
+};
+
+const ALIAS_TO_TOPO: Record<string, string> = {
+  '서울': '서울특별시',
+  '부산': '부산광역시',
+  '대구': '대구광역시',
+  '인천': '인천광역시',
+  '광주': '광주광역시',
+  '대전': '대전광역시',
+  '울산': '울산광역시',
+  '세종': '세종특별자치시',
+  '경기': '경기도',
+  '강원': '강원도',
+  '강원특별자치도': '강원도',
+  '충북': '충청북도',
+  '충남': '충청남도',
+  '전북': '전라북도',
+  '전북특별자치도': '전라북도',
+  '전남': '전라남도',
+  '경북': '경상북도',
+  '경남': '경상남도',
+  '제주': '제주특별자치도',
 };
 
 type PeriodType = '1day' | '3days' | '7days' | '30days' | 'custom';
@@ -105,22 +127,23 @@ export default function AnimalStats() {
   const [hoveredRegion, setHoveredRegion] = useState<string | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
 
+  const toTopoName = (name: string) => ALIAS_TO_TOPO[name] ?? name;
+
   const regionCountMap = useMemo(() => {
     const map = new Map<string, number>();
-    regionalStats.forEach((r) => map.set(r.region, r.count));
+    regionalStats.forEach((r) => map.set(toTopoName(r.region), r.count));
     return map;
   }, [regionalStats]);
 
   const getRegionColor = (topoName: string) => {
-    const currentName = NAME_MAP[topoName] ?? topoName;
-    const count = regionCountMap.get(currentName) ?? 0;
+    const count = regionCountMap.get(topoName) ?? 0;
     if (count === 0) return '#f3f4f6';
     const ratio = regionalMax > 0 ? count / regionalMax : 0;
     const lightness = Math.round(85 - ratio * 55);
     return `hsl(0, 0%, ${lightness}%)`;
   };
 
-  const getDisplayName = (topoName: string) => NAME_MAP[topoName] ?? topoName;
+  const getDisplayName = (topoName: string) => TOPO_DISPLAY_MAP[topoName] ?? topoName;
 
   const periodButtons: { key: PeriodType; label: string }[] = [
     { key: '1day', label: '1일' },
@@ -303,7 +326,7 @@ export default function AnimalStats() {
                         className="pointer-events-none absolute z-10 rounded-lg bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-3 py-2 text-xs font-semibold shadow-lg"
                         style={{ left: tooltipPos.x, top: tooltipPos.y, transform: 'translate(-50%, -120%)' }}
                       >
-                        {hoveredRegion} · {regionCountMap.get(hoveredRegion)?.toLocaleString() ?? 0}건
+                        {getDisplayName(hoveredRegion)} · {regionCountMap.get(hoveredRegion)?.toLocaleString() ?? 0}건
                       </div>
                     )}
                     <ComposableMap
@@ -329,7 +352,7 @@ export default function AnimalStats() {
                                 onMouseEnter={(e) => {
                                   const container = (e.target as SVGElement).closest('svg')!.parentElement!;
                                   const rect = container.getBoundingClientRect();
-                                  setHoveredRegion(getDisplayName(topoName));
+                                  setHoveredRegion(topoName);
                                   setTooltipPos({
                                     x: e.clientX - rect.left,
                                     y: e.clientY - rect.top,
@@ -370,7 +393,7 @@ export default function AnimalStats() {
                                 onMouseEnter={(e) => {
                                   const container = (e.target as SVGElement).closest('svg')!.parentElement!;
                                   const rect = container.getBoundingClientRect();
-                                  setHoveredRegion(getDisplayName(topoName));
+                                  setHoveredRegion(topoName);
                                   setTooltipPos({
                                     x: e.clientX - rect.left,
                                     y: e.clientY - rect.top,
@@ -414,13 +437,14 @@ export default function AnimalStats() {
                         const rank = idx === 0 || region.count !== regionalStats[idx - 1].count
                           ? idx + 1
                           : regionalStats.findIndex((r) => r.count === region.count) + 1;
+                        const displayRegion = getDisplayName(toTopoName(region.region));
                         return (
                           <div key={region.region} className="flex items-center gap-4 px-5 py-3.5">
                             <span className="text-sm font-bold text-gray-400 dark:text-gray-500 w-6 text-right flex-shrink-0">
                               {rank}
                             </span>
                             <span className="text-sm font-semibold text-text-light dark:text-text-dark w-28 flex-shrink-0">
-                              {region.region}
+                              {displayRegion}
                             </span>
                             <div className="flex-1 min-w-0">
                               <div className="w-full h-5 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">


### PR DESCRIPTION
## 변경 사항

### 지역별 구조 통계 지도 지역명 매칭 버그 수정
- 백엔드에서 축약 지역명(예: "전남")을 반환할 때 TopoJSON 지도 데이터("전라남도")와 매칭되지 않아 지도에 색상이 표시되지 않던 문제 수정
- `ALIAS_TO_TOPO` 매핑 추가: 17개 시/도의 축약명·현행명 → TopoJSON 이름 변환
  - 축약명 대응: 서울, 부산, 대구, 인천, 광주, 대전, 울산, 세종, 경기, 강원, 충북, 충남, 전북, 전남, 경북, 경남, 제주
  - 현행명 대응: 강원특별자치도→강원도, 전북특별자치도→전라북도
- `regionCountMap` 생성 시 백엔드 이름을 TopoJSON 이름으로 정규화
- 툴팁: TopoJSON 이름으로 count 조회 후 표시명은 현행명으로 변환
- 막대 그래프: 축약명 대신 정식 이름으로 표시

## 작업 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명

- 백엔드 API 명세상 region은 "시/도 풀네임"으로 정의되어 있으나, 실제 응답에서 축약명이 포함될 수 있어 프론트에서 양방향 대응
- 어떤 형태(축약명/정식명/현행명)로 오더라도 지도에 정상 매칭됨