### PR TITLE
fix: 메인 페이지 미구현 후원 캠페인 배너 제거

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -460,26 +460,6 @@ export default function Home() {
             </div>
           </section>
 
-          {/* Campaign Banner */}
-          <section className="w-full mt-16 md:mt-24">
-            <div className="w-full bg-primary/20 dark:bg-primary/30 rounded-xl p-8 md:p-12 flex flex-col md:flex-row items-center justify-between gap-8">
-              <div className="text-center md:text-left">
-                <h3 className="text-primary-content dark:text-white text-2xl font-bold">
-                  겨울맞이 후원 캠페인
-                </h3>
-                <p className="text-secondary-content dark:text-gray-300 mt-2">
-                  추운 겨울, 아이들이 따뜻하게 지낼 수 있도록 마음을 모아주세요.
-                </p>
-              </div>
-              <Link
-                to="/donate"
-                className="flex-shrink-0 flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-12 px-6 bg-primary text-primary-content text-base font-bold leading-normal tracking-[0.015em] hover:opacity-90 transition-opacity"
-              >
-                <span className="truncate">자세히 보기</span>
-              </Link>
-            </div>
-          </section>
-
           {/* Adoption Stories */}
           <section className="w-full mt-16 md:mt-24">
             <div className="flex justify-between items-center mb-6">


### PR DESCRIPTION
## 변경 사항

### 메인 페이지 후원 캠페인 배너 제거
- "겨울맞이 후원 캠페인" 섹션 전체 제거
- 미구현 페이지(/donate)로의 링크 제거
- 후원 기능 개발 시 재추가 예정

## 작업 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명

- /donate 페이지가 미구현 상태로 404 발생 방지
- 계절에 맞지 않는 "겨울맞이" 문구 정리