### PR TITLE
fix: 공공데이터 API 오류 안내 팝업 제거

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,22 +10,7 @@ import AnimalCardSimple from '../components/common/AnimalCardSimple';
 import QuickNavCard from '../components/common/QuickNavCard';
 import AdoptionStory from '../components/common/AdoptionStory';
 
-const POPUP_KEY = 'data-update-notice-hidden';
-
 export default function Home() {
-  const [showNotice, setShowNotice] = useState(false);
-
-  useEffect(() => {
-    const hidden = localStorage.getItem(POPUP_KEY);
-    if (!hidden) setShowNotice(true);
-  }, []);
-
-  const closeNotice = () => setShowNotice(false);
-  const hideNoticeForToday = () => {
-    localStorage.setItem(POPUP_KEY, new Date().toDateString());
-    setShowNotice(false);
-  };
-
   const { data: todayStats } = useQuery({
     queryKey: ['today-animal-stats'],
     queryFn: getTodayAnimalStats,
@@ -504,36 +489,6 @@ export default function Home() {
       </main>
 
       <Footer />
-
-      {showNotice && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="mx-4 w-full max-w-md rounded-2xl bg-white dark:bg-gray-900 shadow-xl border border-gray-200 dark:border-gray-700 p-6 flex flex-col gap-4 text-center">
-            <div className="flex items-center justify-center">
-              <span className="material-symbols-outlined text-4xl text-yellow-500">warning</span>
-            </div>
-            <p className="text-xl font-bold text-text-light dark:text-text-dark">데이터 갱신 안내</p>
-            <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
-              공공데이터 API 오류로 인하여<br />
-              데이터 갱신이 불가능합니다.<br /><br />
-              다음 주 내로 정상적으로 데이터 갱신 예정입니다.
-            </p>
-            <div className="flex flex-col gap-2 mt-2">
-              <button
-                onClick={closeNotice}
-                className="w-full rounded-lg h-11 bg-primary text-primary-content text-sm font-bold hover:opacity-90 transition-opacity"
-              >
-                확인
-              </button>
-              <button
-                onClick={hideNoticeForToday}
-                className="w-full text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors py-2"
-              >
-                오늘 하루 보지 않기
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## 변경 사항

### 메인 페이지 데이터 갱신 안내 팝업 추가
- 공공데이터 API 오류로 인한 데이터 갱신 불가 안내 팝업 추가
- "확인" 버튼으로 닫기
- "오늘 하루 보지 않기" 기능 (localStorage 활용)
- 반응형 및 다크모드 지원

## 작업 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명

- 공공데이터 API 정상화 후 팝업 코드 제거 예정
- 이전 서버 점검 팝업과 동일한 UX 패턴 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 홈 페이지의 데이터 업데이트 알림 팝업이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->