### PR TITLE
feat: 동물 상세 페이지에 유사 동물 추천 섹션 추가

### DIFF
--- a/src/api/animals.api.ts
+++ b/src/api/animals.api.ts
@@ -177,6 +177,22 @@ export const uploadAnimalImages = async (files: File[]): Promise<AnimalImagesUpl
   return response.data;
 };
 
+// 유사 동물 목록 조회
+export const getSimilarAnimals = async (id: number): Promise<Animal[]> => {
+  const response = await apiClient.get<Animal[] | { code: number; data: Animal[]; message: string }>(
+    `/api/animals/${id}/similar`
+  );
+  const data = response.data;
+
+  if (Array.isArray(data)) {
+    return data;
+  }
+  if (data && typeof data === 'object' && 'data' in data && Array.isArray(data.data)) {
+    return data.data;
+  }
+  return [];
+};
+
 // 이미지 삭제
 export const deleteAnimalImage = async (imageUrl: string): Promise<void> => {
   await apiClient.delete('/api/animals/images', {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -56,7 +56,7 @@ apiClient.interceptors.response.use(
           const requestUrl = error.config?.url || '';
           
           // 공개 API 경로 패턴: /api/animals 또는 /api/animals/{id}
-          const isPublicAnimalApi = /^\/api\/animals(\/\d+)?(\?.*)?$/.test(requestUrl);
+          const isPublicAnimalApi = /^\/api\/animals(\/\d+(\/similar)?)?(\?.*)?$/.test(requestUrl);
           
           if (isPublicAnimalApi) {
             // 공개 API는 에러만 로그하고 리다이렉트하지 않음

--- a/src/pages/AnimalDetail.tsx
+++ b/src/pages/AnimalDetail.tsx
@@ -1,9 +1,10 @@
 import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getAnimalById, checkFavorite, addFavorite, removeFavorite } from '../api/animals.api';
+import { getAnimalById, checkFavorite, addFavorite, removeFavorite, getSimilarAnimals } from '../api/animals.api';
 import { useAuthStore } from '../store/authStore';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
+import AnimalCardSimple from '../components/common/AnimalCardSimple';
 import { useState, useEffect } from 'react';
 
 export default function AnimalDetail() {
@@ -13,6 +14,12 @@ export default function AnimalDetail() {
   const queryClient = useQueryClient();
   const user = useAuthStore((state) => state.user);
   const [selectedImage, setSelectedImage] = useState<string>('');
+
+  // 상세 페이지 전환 시 스크롤 초기화 및 이미지 선택 리셋
+  useEffect(() => {
+    window.scrollTo(0, 0);
+    setSelectedImage('');
+  }, [id]);
 
   // 이전 페이지 정보 확인 (마이페이지에서 온 경우)
   const fromMyPage = location.state?.from === 'mypage';
@@ -92,6 +99,13 @@ export default function AnimalDetail() {
       });
     }
   }, [animal, user, isManualAnimal, isMyShelter, isMyAnimal]);
+
+  // 유사 동물 목록 조회
+  const { data: similarAnimals } = useQuery({
+    queryKey: ['similarAnimals', id],
+    queryFn: () => getSimilarAnimals(Number(id)),
+    enabled: !!id,
+  });
 
   // 찜 여부 확인
   const { data: isFavorited } = useQuery({
@@ -623,6 +637,23 @@ export default function AnimalDetail() {
             </div>
           </div>
         </div>
+
+        {/* 유사 동물 추천 */}
+        {similarAnimals && similarAnimals.length > 0 && (
+          <section className="mt-12">
+            <div className="flex items-center gap-3 mb-6">
+              <span className="material-symbols-outlined text-2xl text-primary">pets</span>
+              <h2 className="text-2xl font-bold text-text-light dark:text-text-dark">
+                이 동물과 비슷한 친구들
+              </h2>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              {similarAnimals.slice(0, 6).map((similarAnimal) => (
+                <AnimalCardSimple key={similarAnimal.id} animal={similarAnimal} />
+              ))}
+            </div>
+          </section>
+        )}
       </main>
 
       <Footer />


### PR DESCRIPTION
## 변경 사항

### 동물 상세 페이지 하단에 유사 동물 추천 섹션 추가
- Python AI 서버의 이미지 유사도 분석을 활용한 유사 동물 추천 기능
- GET /api/animals/{id}/similar API 호출 (게이트웨이 경유)
- 기존 AnimalCardSimple 컴포넌트 재사용하여 카드 표시
- 코사인 유사도 0.6 이상인 동물만 표시 (최대 6개, min_score에 따라 더 적을 수 있음)
- 응답이 빈 배열이면 섹션 미표시
- 카드 클릭 시 해당 동물 상세 페이지로 이동 및 스크롤 초기화
- 반응형 레이아웃 (모바일 2열 / 태블릿+ 3열) 및 다크모드 지원
- 공개 API 정규식에 /similar 경로 매칭 추가

## 작업 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 동물 상세 페이지에서 유사한 동물들을 추천으로 확인할 수 있는 기능이 추가되었습니다. 사용자는 현재 보고 있는 동물과 비슷한 다른 동물들을 한눈에 볼 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->