### PR TITLE
feat(home): 홈 입양 후기 섹션 API 연동

### DIFF
--- a/src/components/common/AdoptionStory.tsx
+++ b/src/components/common/AdoptionStory.tsx
@@ -1,18 +1,30 @@
+import { Link } from 'react-router-dom';
+
 interface AdoptionStoryProps {
+  postId: number;
   tag: string;
   title: string;
   excerpt: string;
-  imageUrl: string;
+  imageUrl?: string | null;
 }
 
-export default function AdoptionStory({ tag, title, excerpt, imageUrl }: AdoptionStoryProps) {
+export default function AdoptionStory({ postId, tag, title, excerpt, imageUrl }: AdoptionStoryProps) {
   return (
-    <div className="flex flex-col sm:flex-row items-center gap-6 group cursor-pointer">
+    <Link
+      to={`/adoption/${postId}`}
+      className="flex flex-col sm:flex-row items-center gap-6 group cursor-pointer"
+    >
       <div className="w-full sm:w-1/3 flex-shrink-0">
-        <div
-          className="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-xl"
-          style={{ backgroundImage: `url("${imageUrl}")` }}
-        />
+        {imageUrl ? (
+          <div
+            className="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-xl"
+            style={{ backgroundImage: `url("${imageUrl}")` }}
+          />
+        ) : (
+          <div className="w-full aspect-square rounded-xl bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+            <span className="material-symbols-outlined text-gray-400 dark:text-gray-500 text-5xl">image</span>
+          </div>
+        )}
       </div>
       <div className="text-center sm:text-left">
         <p className="text-secondary-content dark:text-gray-400 text-sm">{tag}</p>
@@ -23,8 +35,6 @@ export default function AdoptionStory({ tag, title, excerpt, imageUrl }: Adoptio
           {excerpt}
         </p>
       </div>
-    </div>
+    </Link>
   );
 }
-
-

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,9 @@
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, useMemo } from 'react';
 import { getAnimals } from '../api/animals.api';
 import { getTodayAnimalStats, getAnimalStatusStats } from '../api/animalStats.api';
+import { getAllPosts } from '../api/community.api';
 import type { Animal } from '../types/api.types';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
@@ -49,6 +50,28 @@ export default function Home() {
 
   // 최근 등록 동물 (20마리)
   const featuredAnimals = data?.content?.slice(0, 20) || [];
+
+  const { data: posts = [], isLoading: isAdoptionPostsLoading } = useQuery({
+    queryKey: ['posts'],
+    queryFn: getAllPosts,
+  });
+
+  const latestAdoptionPosts = useMemo(
+    () => posts.filter((p) => p.boardType === 'ADOPTION').slice(0, 2),
+    [posts],
+  );
+
+  const resolvePostImage = (urls?: string[]) => {
+    if (!urls?.length) return null;
+    const first = urls[0];
+    return first || null;
+  };
+
+  const toExcerpt = (content: string, maxLength = 120) => {
+    const plain = content.replace(/\s+/g, ' ').trim();
+    if (plain.length <= maxLength) return plain;
+    return `${plain.slice(0, maxLength)}...`;
+  };
 
   // 마우스 드래그 스크롤을 위한 ref와 state
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -470,20 +493,32 @@ export default function Home() {
                 더보기
               </Link>
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-              <AdoptionStory
-                tag="입양 1주년"
-                title="우리 집에 온 작은 천사, 뽀삐"
-                excerpt="뽀삐가 가족이 된 후로 저희 집에는 웃음꽃이 떠나질 않아요. 처음에는 낯을 많이 가렸지만..."
-                imageUrl="https://lh3.googleusercontent.com/aida-public/AB6AXuCfhMqa7lyzEriR5tR0Dne9U5bpdmulNK7_eSGZ2MLZBCvl4bjhTENwUToOfPUe2YUeY5AVAmSnLzNb_Gv4hgjMgiitAa8sh_c_0oPaTAyFWrSLX5gdHfU-Ag-RMlYO4F9bVqQ8xcHk5tZIVu95ADLci19G_ryX3DrZLkK7Eb2wdu1rUFSsD6uZnXdRZqBtWC9lGN9aMxy0fmU2ALXuZnLeIAvpTZR680HHG0k1kI9LixavviwlaJZnBriwdchHshkib_LPZNE-j3U"
-              />
-              <AdoptionStory
-                tag="최신 후기"
-                title="소심했던 고양이, 이제는 애교쟁이!"
-                excerpt="보호소에서 유독 조용했던 나비. 집에 온 첫날에는 숨기만 했는데, 이제는 제 무릎에서..."
-                imageUrl="https://lh3.googleusercontent.com/aida-public/AB6AXuC3MSPHepbUpXu_0jONMbZPFUuHuDz6-knINiiO51kU93h2vn-_GAPeoT1X7WKh9b7lyGOfn_Y8fFy5dBqxREj3VLLk1k65XFpIh28MhK0yqJMPA_p_HB7DPibTlPDG8Aouw0utlzghlCP_x6Iq8FNFBVF0BSj1b50YisKQ3KKzNpnocPr92kQjlSA8ItV5DTJfjABPGaRq_qpvmV52EJ2S6ntmIbc24T1mmA6F_IF6kYVkHvyvMHjeyP2sIV26bj8rzgE4OLzLznw"
-              />
-            </div>
+            {isAdoptionPostsLoading ? (
+              <p className="text-center text-gray-500 dark:text-gray-400 py-8">입양 후기를 불러오는 중...</p>
+            ) : latestAdoptionPosts.length === 0 ? (
+              <p className="text-center text-gray-500 dark:text-gray-400 py-8">
+                아직 입양 후기가 없습니다.{' '}
+                <Link to="/adoption" className="text-primary font-bold hover:underline">
+                  후기 보러 가기
+                </Link>
+              </p>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                {latestAdoptionPosts.map((post) => {
+                  const postId = post.postId ?? post.id;
+                  return (
+                    <AdoptionStory
+                      key={postId}
+                      postId={postId}
+                      tag={new Date(post.createdAt).toLocaleDateString('ko-KR')}
+                      title={post.title}
+                      excerpt={toExcerpt(post.content)}
+                      imageUrl={resolvePostImage(post.imageUrls)}
+                    />
+                  );
+                })}
+              </div>
+            )}
           </section>
         </div>
       </main>


### PR DESCRIPTION
## 변경 사항

홈 「행복한 입양 후기」 섹션을 입양후기 목록과 동일한 데이터 소스로 연동

**[1] 하드코딩 더미 제거**
- 기존: 고정 문구·외부 목업 이미지 2건 (`AdoptionStory` 정적 props)
- 변경: Community API `GET /api/posts/read` → `boardType === 'ADOPTION'` 필터 → 최신 2건

**[2] Home.tsx**
- `getAllPosts()` + React Query (`queryKey: ['posts']`, `/adoption` 목록과 동일)
- `createdAt` 내림차순(백엔드 기본 정렬) 기준 상위 2건 `slice(0, 2)`
- 로딩 문구 / 후기 0건 시 CTA(`후기 보러 가기` → `/adoption`)
- 본문 요약 120자, 작성일 태그, 썸네일 `imageUrls[0]`

**[3] AdoptionStory.tsx**
- `postId` 추가 → `/adoption/{id}` 링크
- 이미지 없을 때 placeholder (입양후기 목록과 동일 패턴)
- `cursor-pointer`만 있던 비클릭 카드 문제 해소

## 작업 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 체크리스트

- [ ] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 입양 후기 카드를 클릭하여 상세 페이지로 이동할 수 있습니다.
  * 입양 후기가 실시간 게시글 데이터로 동적으로 로드됩니다.
  * 최신 입양 후기 상위 2개가 자동으로 표시됩니다.

* **개선 사항**
  * 입양 후기 이미지가 없을 경우 기본 아이콘이 표시됩니다.
  * 입양 후기 작성 날짜가 한국어 형식으로 표시됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawbridge/pawbridge-frontend/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->